### PR TITLE
feat: add protected app shell with supabase demo auth

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-VITE_SUPABASE_PROJECT_ID="ajrswsxnlkgauhkiedfc"
-VITE_SUPABASE_PUBLISHABLE_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFqcnN3c3hubGtnYXVoa2llZGZjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTE4OTg4NjUsImV4cCI6MjA2NzQ3NDg2NX0.0gUHAsEOEVxZwjOizqQ6bbcSIBxsEGwDNIDJ5xWVXpA"
-VITE_SUPABASE_URL="https://ajrswsxnlkgauhkiedfc.supabase.co"
-VITE_STRIPE_BETA_LINK="https://dashboard.stripe.com/test/pay/your_beta_link"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Lint
+        run: pnpm lint
+
       - name: Validate landing content
         run: |
           set -euo pipefail
@@ -66,3 +69,19 @@ jobs:
 
       - name: Test
         run: pnpm test -- --run
+
+  preview:
+    name: Preview Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'pull_request' && secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != ''
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Vercel
+        uses: vercel/action@v3
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
+.env.*
+.env.local
+.env.development
+.env.production
+.env.test
 
 # Editor directories and files
 .vscode/*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,79 @@
-import NewLandingPage from "./components/landing/NewLandingPage";
+import { Suspense, lazy } from "react";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { ProtectedRoute } from "@/components/ProtectedRoute";
 
-const App = () => <NewLandingPage />;
+const LandingPage = lazy(() => import("@/components/landing/NewLandingPage"));
+const Login = lazy(() => import("@/pages/auth/Login"));
+const ClientLayout = lazy(() => import("@/layouts/ClientLayout"));
+const AdminLayout = lazy(() => import("@/layouts/AdminLayout"));
+const ClientOverview = lazy(() => import("@/pages/app/Overview"));
+const ClientRoadmap = lazy(() => import("@/pages/app/Roadmap"));
+const ClientTasks = lazy(() => import("@/pages/app/Tasks"));
+const ClientFiles = lazy(() => import("@/pages/app/Files"));
+const ClientDiscussions = lazy(() => import("@/pages/app/Discussions"));
+const ClientSettings = lazy(() => import("@/pages/app/Settings"));
+const AdminDashboard = lazy(() => import("@/pages/admin/Dashboard"));
+const AdminClients = lazy(() => import("@/pages/admin/Clients"));
+const AdminRoadmaps = lazy(() => import("@/pages/admin/Roadmaps"));
+const AdminBilling = lazy(() => import("@/pages/admin/Billing"));
+const AdminIntegrations = lazy(() => import("@/pages/admin/Integrations"));
+const AdminSettings = lazy(() => import("@/pages/admin/Settings"));
+const NotFound = lazy(() => import("@/pages/NotFound"));
+
+const Fallback = () => (
+  <div className="flex min-h-screen items-center justify-center bg-gradient-subtle">
+    <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground">
+      <span className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-primary" />
+      Chargement de l'expérience Æditus…
+    </div>
+  </div>
+);
+
+const App = () => (
+  <BrowserRouter>
+    <Suspense fallback={<Fallback />}>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/login" element={<Login />} />
+
+        <Route
+          path="/app"
+          element={
+            <ProtectedRoute role="client">
+              <ClientLayout />
+            </ProtectedRoute>
+          }
+        >
+          <Route index element={<ClientOverview />} />
+          <Route path="roadmap" element={<ClientRoadmap />} />
+          <Route path="tasks" element={<ClientTasks />} />
+          <Route path="files" element={<ClientFiles />} />
+          <Route path="discussions" element={<ClientDiscussions />} />
+          <Route path="settings" element={<ClientSettings />} />
+        </Route>
+
+        <Route
+          path="/admin"
+          element={
+            <ProtectedRoute role="admin">
+              <AdminLayout />
+            </ProtectedRoute>
+          }
+        >
+          <Route index element={<AdminDashboard />} />
+          <Route path="clients" element={<AdminClients />} />
+          <Route path="roadmaps" element={<AdminRoadmaps />} />
+          <Route path="billing" element={<AdminBilling />} />
+          <Route path="integrations" element={<AdminIntegrations />} />
+          <Route path="settings" element={<AdminSettings />} />
+        </Route>
+
+        <Route path="/app/*" element={<Navigate to="/app" replace />} />
+        <Route path="/admin/*" element={<Navigate to="/admin" replace />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </Suspense>
+  </BrowserRouter>
+);
 
 export default App;

--- a/src/compat/framer-motion.tsx
+++ b/src/compat/framer-motion.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import {
   createElement,
   forwardRef,

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,44 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+import { useQuery } from "@/lib/query";
+import { supabase } from "@/lib/supabaseClient";
+
+export function ProtectedRoute({ children, role }: { children: JSX.Element; role?: "admin" | "client" }) {
+  const { user, loading } = useAuth();
+  const { data: profile, isLoading, isError } = useQuery({
+    queryKey: ["profiles", user?.id],
+    queryFn: async () => {
+      const response = await supabase.from("profiles").select("role").single();
+      if (response.error) {
+        throw response.error;
+      }
+      return response.data;
+    },
+    enabled: Boolean(user),
+  });
+
+  if (loading || isLoading) {
+    return (
+      <div className="flex h-[50vh] items-center justify-center" aria-busy>
+        <div className="flex flex-col items-center gap-2 text-sm text-muted-foreground">
+          <span className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-primary" />
+          <p>Chargement de votre espace sécurisé…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (isError) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (role && profile?.role !== role) {
+    return <Navigate to={profile?.role === "admin" ? "/admin" : "/app"} replace />;
+  }
+
+  return children;
+}

--- a/src/components/landing/NewLandingPage.tsx
+++ b/src/components/landing/NewLandingPage.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable react-refresh/only-export-components */
 import React, { useMemo, useState } from "react";
 import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
 import {
   Sparkles,
   Calendar,
@@ -328,6 +330,8 @@ if (typeof window !== "undefined") {
 
 export default function AeditusLanding() {
   const [billing, setBilling] = useState<"mensuel" | "annuel">("mensuel");
+  const [betaNotice, setBetaNotice] = useState<string | null>(null);
+  const stripeBetaLink = (import.meta.env.VITE_STRIPE_BETA_LINK as string | undefined)?.trim();
 
   const prices = useMemo(
     () => ({
@@ -370,17 +374,26 @@ export default function AeditusLanding() {
             <span className="font-heading text-white/90 group-hover:text-white">Æditus</span>
           </a>
           <div className="hidden items-center gap-6 md:flex">
-            <a href="#about" className="text-sm text-white/70 hover:text-white">Fonctionnalités</a>
-            <a href="#semaine-type" className="text-sm text-white/70 hover:text-white">Comment ça marche</a>
-            <a href="#offres" className="text-sm text-white/70 hover:text-white">Offres</a>
-            <a href="#faq" className="text-sm text-white/70 hover:text-white">FAQ</a>
-          </div>
-          <div className="flex items-center gap-3">
-            <a href="#offres" className="hidden rounded-xl border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/5 md:inline-flex">Voir les offres</a>
-            <a href="#offres" className="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-[#0B1110] hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60">
-              Démarrer l’essai 7 jours <ChevronRight className="h-4 w-4" />
-            </a>
-          </div>
+          <a href="#about" className="text-sm text-white/70 hover:text-white">Fonctionnalités</a>
+          <a href="#semaine-type" className="text-sm text-white/70 hover:text-white">Comment ça marche</a>
+          <a href="#offres" className="text-sm text-white/70 hover:text-white">Offres</a>
+          <a href="#faq" className="text-sm text-white/70 hover:text-white">FAQ</a>
+          <Link to="/app" className="text-sm text-white/70 transition hover:text-white">
+            Plateforme
+          </Link>
+        </div>
+        <div className="flex items-center gap-3">
+          <Link
+            to="/app"
+            className="hidden rounded-xl border border-white/10 px-4 py-2 text-sm text-white/80 transition hover:bg-white/5 md:inline-flex"
+          >
+            Voir la plateforme
+          </Link>
+          <a href="#offres" className="hidden rounded-xl border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/5 md:inline-flex">Voir les offres</a>
+          <a href="#offres" className="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-[#0B1110] hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60">
+            Démarrer l’essai 7 jours <ChevronRight className="h-4 w-4" />
+          </a>
+        </div>
         </nav>
       </header>
 
@@ -403,17 +416,49 @@ export default function AeditusLanding() {
             <motion.p variants={fadeUp} initial="hidden" whileInView="show" custom={2} viewport={{ once: true }} className={`${sub} mt-4`}>
               Plan éditorial complet chaque mois. Publications hebdomadaires sur tous vos réseaux, en 2 clics — gain : +10 h de travail/mois. Vidéos & visuels inclus. Option : tout en automatique (réversible).
             </motion.p>
-            <motion.div variants={fadeUp} initial="hidden" whileInView="show" custom={3} viewport={{ once: true }} className="mt-8 flex flex-wrap items-center gap-3">
-              <a href="#offres" className="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-5 py-3 text-sm font-semibold text-[#0B1110] shadow-lg shadow-indigo-500/20 hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60">
-                Démarrer l’essai 7 jours <ChevronRight className="h-4 w-4" />
-              </a>
-              <a href="#offres" className="inline-flex items-center gap-2 rounded-xl border border-white/10 px-5 py-3 text-sm font-semibold text-white/80 hover:bg-white/5">
-                Voir les offres
-              </a>
-              <a href="#compare" className="inline-flex items-center gap-2 rounded-xl border border-white/10 px-5 py-3 text-sm font-semibold text-white/80 hover:bg-white/5">
-                Comparer aux autres solutions
-              </a>
-            </motion.div>
+              <motion.div variants={fadeUp} initial="hidden" whileInView="show" custom={3} viewport={{ once: true }} className="mt-8 flex flex-wrap items-center gap-3">
+                <Link
+                  to="/app"
+                  className="inline-flex items-center gap-2 rounded-xl border border-white/20 px-5 py-3 text-sm font-semibold text-white/90 shadow-lg shadow-indigo-500/20 transition hover:border-white/40 hover:text-white"
+                >
+                  Explorer la plateforme <ChevronRight className="h-4 w-4" />
+                </Link>
+                <a href="#offres" className="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-5 py-3 text-sm font-semibold text-[#0B1110] shadow-lg shadow-indigo-500/20 hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60">
+                  Démarrer l’essai 7 jours <ChevronRight className="h-4 w-4" />
+                </a>
+                <a href="#offres" className="inline-flex items-center gap-2 rounded-xl border border-white/10 px-5 py-3 text-sm font-semibold text-white/80 hover:bg-white/5">
+                  Voir les offres
+                </a>
+                <a href="#compare" className="inline-flex items-center gap-2 rounded-xl border border-white/10 px-5 py-3 text-sm font-semibold text-white/80 hover:bg-white/5">
+                  Comparer aux autres solutions
+                </a>
+                <a
+                  href={stripeBetaLink || "#offres"}
+                  onClick={(event) => {
+                    if (!stripeBetaLink) {
+                      event.preventDefault();
+                      setBetaNotice("Lien Stripe indisponible : la bêta privée est complète. Contactez-nous via Alfie pour une invitation.");
+                    } else {
+                      setBetaNotice(null);
+                    }
+                  }}
+                  className="inline-flex items-center gap-2 rounded-xl border border-amber-300/40 bg-amber-200/20 px-5 py-3 text-sm font-semibold text-amber-100 shadow-lg shadow-amber-300/20 transition hover:bg-amber-200/30"
+                >
+                  Rejoindre la bêta <ChevronRight className="h-4 w-4" />
+                </a>
+              </motion.div>
+              {betaNotice && (
+                <motion.p
+                  variants={fadeUp}
+                  initial="hidden"
+                  whileInView="show"
+                  custom={4}
+                  viewport={{ once: true }}
+                  className="mt-4 max-w-lg rounded-xl border border-amber-300/30 bg-amber-200/10 px-4 py-3 text-xs text-amber-100"
+                >
+                  {betaNotice}
+                </motion.p>
+              )}
             <motion.ul variants={fadeUp} initial="hidden" whileInView="show" custom={4} viewport={{ once: true }} className="mt-5 flex flex-wrap gap-2 text-xs text-white/70">
               <li className="rounded-full border border-white/10 bg-white/5 px-3 py-1">Plan mensuel</li>
               <li className="rounded-full border border-white/10 bg-white/5 px-3 py-1">Publication hebdo multi‑réseaux</li>
@@ -644,6 +689,7 @@ export default function AeditusLanding() {
                 "Option : articles & Fynk activables"
               ]}
               cta="Choisir Essential"
+              ctaLink="/app"
               highlight={false}
             />
             <PriceCard
@@ -663,6 +709,7 @@ export default function AeditusLanding() {
                 "Essai 7 jours (sans publication)"
               ]}
               cta="Choisir Starter"
+              ctaLink="/app"
               highlight={false}
             />
             <PriceCard
@@ -682,6 +729,7 @@ export default function AeditusLanding() {
                 "Essai 7 jours (sans publication)"
               ]}
               cta="Choisir Pro"
+              ctaLink="/admin"
               highlight
             />
           </div>
@@ -745,6 +793,7 @@ export default function AeditusLanding() {
               ]}
               note="1 marque/abo · annulation à tout moment"
               cta="Choisir Fynk Basic"
+              ctaLink="/app/settings"
             />
             <AddOnCard
               title="Fynk Pro — 69€ /mois"
@@ -758,6 +807,7 @@ export default function AeditusLanding() {
               ]}
               note="1 marque/abo · annulation à tout moment"
               cta="Choisir Fynk Pro"
+              ctaLink="/admin/billing"
             />
           </div>
 
@@ -774,9 +824,12 @@ export default function AeditusLanding() {
                   <li>Affiliation activée : 10 % par parrainage, <strong>15 % à partir de 20 clients</strong></li>
                 </ul>
               </div>
-              <a href="#" className="inline-flex items-center gap-2 rounded-xl bg-white px-5 py-3 text-sm font-semibold text-[#0B1110] hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-white/60">
+              <Link
+                to="/app/roadmap"
+                className="inline-flex items-center gap-2 rounded-xl bg-white px-5 py-3 text-sm font-semibold text-[#0B1110] hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-white/60"
+              >
                 Devenir Ambassadeur <ChevronRight className="h-4 w-4" />
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -842,9 +895,12 @@ export default function AeditusLanding() {
                   <li>Affiliation activée : 10 % par parrainage, <strong>15 % à partir de 20 clients</strong></li>
                 </ul>
               </div>
-              <a href="#" className="inline-flex items-center gap-2 rounded-xl bg-white px-5 py-3 text-sm font-semibold text-[#0B1110] hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-white/60">
+              <Link
+                to="/app/roadmap"
+                className="inline-flex items-center gap-2 rounded-xl bg-white px-5 py-3 text-sm font-semibold text-[#0B1110] hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-white/60"
+              >
                 Devenir Ambassadeur <ChevronRight className="h-4 w-4" />
-              </a>
+              </Link>
             </div>
           </div>
         </div>
@@ -1051,7 +1107,8 @@ function PriceCard({
   highlight,
   dataTestId,
   strike,
-  discountNote
+  discountNote,
+  ctaLink = "/app"
 }: {
   badge?: string;
   title: string;
@@ -1063,6 +1120,7 @@ function PriceCard({
   dataTestId?: string;
   strike?: string;
   discountNote?: string;
+  ctaLink?: string;
 }) {
   return (
     <div data-testid={dataTestId} className={`relative rounded-2xl border ${highlight ? "border-indigo-400/40 bg-indigo-400/10" : "border-white/10 bg-white/5"} p-6`}>
@@ -1085,14 +1143,37 @@ function PriceCard({
           <li key={i} className="inline-flex items-start gap-2"><Check className="mt-0.5 h-4 w-4 text-indigo-300" /> {p}</li>
         ))}
       </ul>
-      <a href="#" className={`mt-6 inline-flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${highlight ? "bg-indigo-500 text-[#0B1110] hover:bg-indigo-400 focus:ring-indigo-400/60" : "border border-white/10 text-white/80 hover:bg-white/5 focus:ring-white/40"}`}>
+      <Link
+        to={ctaLink}
+        className={`mt-6 inline-flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
+          highlight
+            ? "bg-indigo-500 text-[#0B1110] hover:bg-indigo-400 focus:ring-indigo-400/60"
+            : "border border-white/10 text-white/80 hover:bg-white/5 focus:ring-white/40"
+        }`}
+      >
         {cta} <ChevronRight className="h-4 w-4" />
-      </a>
+      </Link>
     </div>
   );
 }
 
-function AddOnCard({ title, price, points, note, cta, variant }: { title: string; price: string; points: string[]; note?: string; cta?: string; variant?: 'basic' | 'pro' }) {
+function AddOnCard({
+  title,
+  price,
+  points,
+  note,
+  cta,
+  variant,
+  ctaLink = "/app/sandbox"
+}: {
+  title: string;
+  price: string;
+  points: string[];
+  note?: string;
+  cta?: string;
+  variant?: "basic" | "pro";
+  ctaLink?: string;
+}) {
   const isPro = variant === 'pro';
   const frame = isPro ? 'border-cyan-400/40 bg-cyan-400/10' : 'border-indigo-400/40 bg-indigo-400/10';
   const chip = isPro ? 'bg-cyan-400/20 text-cyan-100 border-cyan-400/30' : 'bg-indigo-400/20 text-indigo-100 border-indigo-400/30';
@@ -1110,9 +1191,12 @@ function AddOnCard({ title, price, points, note, cta, variant }: { title: string
       </ul>
       {note && <p className="mt-3 text-xs text-white/50">{note}</p>}
       {cta && (
-        <a href="#" className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 px-4 py-2 text-sm font-semibold text-white/80 hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-white/40">
+        <Link
+          to={ctaLink}
+          className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 px-4 py-2 text-sm font-semibold text-white/80 hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-white/40"
+        >
           {cta} <ChevronRight className="h-4 w-4" />
-        </a>
+        </Link>
       )}
     </div>
   );

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from "react";
+import { Link, useLocation } from "react-router-dom";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/useAuth";
+import { listDemoProfiles, setActiveProfile } from "@/lib/supabaseClient";
+
+export type AppShellMenuItem = {
+  icon: LucideIcon;
+  label: string;
+  href: string;
+  description?: string;
+};
+
+export function AppShell({ menu, children }: { menu: AppShellMenuItem[]; children: React.ReactNode }) {
+  const { pathname } = useLocation();
+  const { user } = useAuth();
+  const profiles = useMemo(() => listDemoProfiles(), []);
+  const activeProfile = profiles.find((profile) => profile.id === user?.id);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background text-foreground">
+      <div className="flex flex-1">
+        <aside className="hidden md:flex w-64 shrink-0 border-r bg-card/80 backdrop-blur">
+          <nav className="flex flex-col gap-1 p-4 w-full">
+            {menu.map((item) => {
+              const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+              const Icon = item.icon;
+              return (
+                <Link
+                  key={item.href}
+                  to={item.href}
+                  className={cn(
+                    "flex items-center gap-3 rounded-xl px-3 py-2 transition-colors hover:bg-muted", 
+                    isActive && "bg-muted text-primary font-semibold"
+                  )}
+                >
+                  <span className="flex h-9 w-9 items-center justify-center rounded-lg border bg-background">
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <span className="flex-1 text-sm leading-tight">
+                    {item.label}
+                    {item.description ? (
+                      <span className="block text-xs text-muted-foreground">{item.description}</span>
+                    ) : null}
+                  </span>
+                </Link>
+              );
+            })}
+          </nav>
+        </aside>
+
+        <main className="flex-1">
+          <header className="h-16 border-b bg-background/70 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+            <div className="flex h-full items-center justify-between px-4">
+              <div className="flex items-center gap-3">
+                <span className="rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Æditus Preview
+                </span>
+                <div className="hidden md:flex items-center rounded-xl border bg-card px-3 py-1.5 text-sm text-muted-foreground shadow-sm">
+                  ⌘K · Recherche & raccourcis
+                </div>
+              </div>
+
+              <label className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">Session</span>
+                <select
+                  className="rounded-lg border bg-card px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                  value={activeProfile?.id ?? "guest"}
+                  onChange={(event) => {
+                    const next = event.target.value;
+                    if (next === "guest") {
+                      setActiveProfile(null);
+                    } else {
+                      setActiveProfile(next);
+                    }
+                  }}
+                >
+                  <option value="guest">Déconnecté</option>
+                  {profiles.map((profile) => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </header>
+          <div className="p-4 lg:p-6 space-y-6">{children}</div>
+        </main>
+      </div>
+
+      <nav className="md:hidden fixed bottom-0 inset-x-0 border-t bg-card/95 backdrop-blur shadow-lg">
+        <div className="grid grid-cols-4 text-xs font-medium">
+          {menu.slice(0, 4).map((item) => {
+            const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+            return (
+              <Link
+                key={item.href}
+                to={item.href}
+                className={cn(
+                  "flex flex-col items-center justify-center gap-1 py-2", 
+                  isActive ? "text-primary" : "text-muted-foreground"
+                )}
+              >
+                <item.icon className="h-4 w-4" />
+                <span>{item.label}</span>
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/src/config/menus.ts
+++ b/src/config/menus.ts
@@ -1,0 +1,31 @@
+import {
+  Building2,
+  CreditCard,
+  Folder,
+  Home,
+  KanbanSquare,
+  LayoutDashboard,
+  ListChecks,
+  MessageSquare,
+  Settings,
+  Webhook,
+} from "lucide-react";
+import type { AppShellMenuItem } from "@/components/layout/AppShell";
+
+export const adminMenu: AppShellMenuItem[] = [
+  { icon: LayoutDashboard, label: "Dashboard", href: "/admin" },
+  { icon: Building2, label: "Clients", href: "/admin/clients" },
+  { icon: KanbanSquare, label: "Roadmaps", href: "/admin/roadmaps" },
+  { icon: CreditCard, label: "Facturation", href: "/admin/billing" },
+  { icon: Webhook, label: "Intégrations", href: "/admin/integrations" },
+  { icon: Settings, label: "Paramètres", href: "/admin/settings" },
+];
+
+export const clientMenu: AppShellMenuItem[] = [
+  { icon: Home, label: "Aperçu", href: "/app" },
+  { icon: KanbanSquare, label: "Roadmap", href: "/app/roadmap" },
+  { icon: ListChecks, label: "Tâches", href: "/app/tasks" },
+  { icon: Folder, label: "Livrables", href: "/app/files" },
+  { icon: MessageSquare, label: "Discussions", href: "/app/discussions" },
+  { icon: Settings, label: "Paramètres", href: "/app/settings" },
+];

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { supabase, getActiveProfile } from "@/lib/supabaseClient";
+
+type User = { id: string } | null;
+
+type AuthState = {
+  user: User;
+  loading: boolean;
+};
+
+export function useAuth(): AuthState {
+  const [user, setUser] = useState<User>(() => {
+    const profile = getActiveProfile();
+    return profile ? { id: profile.id } : null;
+  });
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    supabase.auth.getUser().then(({ data }) => {
+      if (!mounted) return;
+      setUser(data.user ?? null);
+      setLoading(false);
+    });
+
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!mounted) return;
+      setUser(session.user ?? null);
+    });
+
+    return () => {
+      mounted = false;
+      data.subscription.unsubscribe();
+    };
+  }, []);
+
+  return { user, loading };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -39,7 +39,12 @@
 
     --ring: var(--primary);
 
-    --radius: 0.75rem;
+    --radius: 14px;
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --brand: 222 84% 56%;
 
     /* Premium Gradients */
     --gradient-gold: linear-gradient(135deg, hsl(45 45% 50%), hsl(45 55% 65%));

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router-dom";
+import { AppShell } from "@/components/layout/AppShell";
+import { adminMenu } from "@/config/menus";
+
+const AdminLayout = () => (
+  <AppShell menu={adminMenu}>
+    <Outlet />
+  </AppShell>
+);
+
+export default AdminLayout;

--- a/src/layouts/ClientLayout.tsx
+++ b/src/layouts/ClientLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router-dom";
+import { AppShell } from "@/components/layout/AppShell";
+import { clientMenu } from "@/config/menus";
+
+const ClientLayout = () => (
+  <AppShell menu={clientMenu}>
+    <Outlet />
+  </AppShell>
+);
+
+export default ClientLayout;

--- a/src/lib/query.tsx
+++ b/src/lib/query.tsx
@@ -1,0 +1,200 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+type QueryKey = readonly unknown[];
+
+type QueryStatus = "idle" | "loading" | "success" | "error";
+
+type QueryState<T> = {
+  status: QueryStatus;
+  data?: T;
+  error?: unknown;
+  updatedAt: number;
+};
+
+type Listener = () => void;
+
+type QueryOptions<T> = {
+  queryKey: QueryKey;
+  queryFn: () => Promise<T>;
+  enabled?: boolean;
+};
+
+export class QueryClient {
+  private cache = new Map<string, QueryState<unknown>>();
+  private listeners = new Map<string, Set<Listener>>();
+
+  private hash(key: QueryKey): string {
+    return JSON.stringify(key);
+  }
+
+  getState<T>(key: QueryKey): QueryState<T> | undefined {
+    return this.cache.get(this.hash(key)) as QueryState<T> | undefined;
+  }
+
+  setState<T>(key: QueryKey, state: QueryState<T>) {
+    const hashed = this.hash(key);
+    this.cache.set(hashed, state);
+    const subscribers = this.listeners.get(hashed);
+    if (subscribers) {
+      subscribers.forEach((listener) => listener());
+    }
+  }
+
+  subscribe(key: QueryKey, listener: Listener) {
+    const hashed = this.hash(key);
+    if (!this.listeners.has(hashed)) {
+      this.listeners.set(hashed, new Set());
+    }
+    const bucket = this.listeners.get(hashed)!;
+    bucket.add(listener);
+    return () => {
+      bucket.delete(listener);
+      if (bucket.size === 0) {
+        this.listeners.delete(hashed);
+      }
+    };
+  }
+
+  invalidateQueries(partial?: QueryKey) {
+    if (!partial || partial.length === 0) {
+      this.cache.clear();
+      this.listeners.forEach((bucket) => bucket.forEach((listener) => listener()));
+      return;
+    }
+    const hashedPrefix = JSON.stringify(partial);
+    for (const key of Array.from(this.cache.keys())) {
+      if (key.startsWith(hashedPrefix)) {
+        this.cache.delete(key);
+        const bucket = this.listeners.get(key);
+        bucket?.forEach((listener) => listener());
+      }
+    }
+  }
+}
+
+const QueryClientContext = createContext<QueryClient | null>(null);
+
+export function QueryClientProvider({
+  client,
+  children,
+}: {
+  client: QueryClient;
+  children: React.ReactNode;
+}) {
+  const value = useMemo(() => client, [client]);
+  return <QueryClientContext.Provider value={value}>{children}</QueryClientContext.Provider>;
+}
+
+export function useQueryClient() {
+  const client = useContext(QueryClientContext);
+  if (!client) {
+    throw new Error("QueryClientProvider manquant dans l'arbre React.");
+  }
+  return client;
+}
+
+export function useQuery<T>({ queryKey, queryFn, enabled = true }: QueryOptions<T>) {
+  const client = useQueryClient();
+  const [state, setState] = useState<QueryState<T>>(() => {
+    const cached = client.getState<T>(queryKey);
+    if (cached) return cached;
+    return { status: enabled ? "loading" : "idle", updatedAt: Date.now() };
+  });
+  const keyRef = useRef(queryKey);
+  keyRef.current = queryKey;
+
+  useEffect(() => {
+    return client.subscribe(queryKey, () => {
+      const latest = client.getState<T>(keyRef.current);
+      if (latest) {
+        setState(latest);
+      }
+    });
+  }, [client, queryKey]);
+
+  useEffect(() => {
+    let ignore = false;
+    if (!enabled) {
+      setState((prev) => ({ ...prev, status: "idle" }));
+      return () => {
+        ignore = true;
+      };
+    }
+
+    const cached = client.getState<T>(queryKey);
+    if (cached && cached.status === "success") {
+      setState(cached);
+      return () => {
+        ignore = true;
+      };
+    }
+
+    const fetchData = async () => {
+      client.setState<T>(queryKey, { status: "loading", data: cached?.data, updatedAt: Date.now() });
+      try {
+        const data = await queryFn();
+        if (ignore) return;
+        client.setState<T>(queryKey, { status: "success", data, updatedAt: Date.now() });
+      } catch (error) {
+        if (ignore) return;
+        client.setState<T>(queryKey, { status: "error", error, updatedAt: Date.now() });
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      ignore = true;
+    };
+  }, [client, enabled, queryFn, queryKey]);
+
+  return {
+    data: state.data as T | undefined,
+    error: state.error,
+    status: state.status,
+    isLoading: state.status === "loading",
+    isError: state.status === "error",
+    isSuccess: state.status === "success",
+  };
+}
+
+export function useMutation<TVariables, TResult>(
+  mutationFn: (variables: TVariables) => Promise<TResult>,
+  options?: { onSuccess?: (result: TResult) => void; invalidate?: QueryKey }
+) {
+  const client = useQueryClient();
+  const [status, setStatus] = useState<QueryStatus>("idle");
+  const [error, setError] = useState<unknown>(null);
+
+  const mutate = useCallback(
+    async (variables: TVariables) => {
+      setStatus("loading");
+      setError(null);
+      try {
+        const result = await mutationFn(variables);
+        setStatus("success");
+        options?.onSuccess?.(result);
+        if (options?.invalidate) {
+          client.invalidateQueries(options.invalidate);
+        }
+        return result;
+      } catch (err) {
+        setStatus("error");
+        setError(err);
+        throw err;
+      }
+    },
+    [client, mutationFn, options]
+  );
+
+  return { mutate, status, error, isLoading: status === "loading" };
+}

--- a/src/lib/router.tsx
+++ b/src/lib/router.tsx
@@ -1,0 +1,302 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  Children,
+  createContext,
+  isValidElement,
+  type AnchorHTMLAttributes,
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from "react";
+
+const normalizePath = (path: string) => {
+  if (!path) return "/";
+  let value = path.startsWith("/") ? path : `/${path}`;
+  if (value.length > 1 && value.endsWith("/")) {
+    value = value.slice(0, -1);
+  }
+  return value || "/";
+};
+
+const resolvePath = (to: string, basePath: string) => {
+  if (!to) return normalizePath(basePath);
+  if (to.startsWith("/")) return normalizePath(to);
+  const segments = [
+    ...normalizePath(basePath)
+      .split("/")
+      .filter(Boolean),
+    ...to.split("/").filter(Boolean)
+  ];
+  return segments.length ? `/${segments.join("/")}` : "/";
+};
+
+type LocationShape = { pathname: string };
+
+type RouterContextValue = {
+  location: LocationShape;
+  navigate: (to: string, options?: { replace?: boolean }) => void;
+};
+
+const RouterContext = createContext<RouterContextValue | null>(null);
+const RouteContext = createContext<{ basePath: string }>({ basePath: "/" });
+const OutletContext = createContext<ReactNode>(null);
+
+const useRouter = () => {
+  const ctx = useContext(RouterContext);
+  if (!ctx) {
+    throw new Error("Router context introuvable. Placez un Router en amont.");
+  }
+  return ctx;
+};
+
+const useRouteContext = () => useContext(RouteContext);
+
+export const useLocation = () => useRouter().location;
+
+export const Outlet = () => {
+  const outlet = useContext(OutletContext);
+  return <>{outlet}</>;
+};
+
+type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & { to: string };
+
+export const Link = ({ to, onClick, target, rel, ...rest }: LinkProps) => {
+  const router = useRouter();
+  const { basePath } = useRouteContext();
+  const href = resolvePath(to, basePath);
+
+  const handleClick: AnchorHTMLAttributes<HTMLAnchorElement>["onClick"] = (event) => {
+    onClick?.(event);
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      target === "_blank"
+    ) {
+      return;
+    }
+    event.preventDefault();
+    router.navigate(href);
+  };
+
+  return <a {...rest} href={href} onClick={handleClick} target={target} rel={rel} />;
+};
+
+type NavLinkProps = LinkProps & {
+  end?: boolean;
+  className?: string | ((args: { isActive: boolean }) => string);
+  style?: ComponentProps<"a">["style"] | ((args: { isActive: boolean }) => ComponentProps<"a">["style"]);
+};
+
+export const NavLink = ({ end, className, style, ...rest }: NavLinkProps) => {
+  const router = useRouter();
+  const { basePath } = useRouteContext();
+  const href = resolvePath(rest.to, basePath);
+  const current = normalizePath(router.location.pathname);
+  const candidate = normalizePath(href);
+  const isActive = end ? current === candidate : current === candidate || current.startsWith(`${candidate}/`);
+  const computedClass = typeof className === "function" ? className({ isActive }) : className;
+  const computedStyle = typeof style === "function" ? style({ isActive }) : style;
+
+  return <Link {...rest} to={rest.to} className={computedClass} style={computedStyle} />;
+};
+
+type NavigateProps = { to: string; replace?: boolean };
+
+export const Navigate = ({ to, replace }: NavigateProps) => {
+  const router = useRouter();
+  const { basePath } = useRouteContext();
+  const destination = useMemo(() => resolvePath(to, basePath), [to, basePath]);
+
+  useEffect(() => {
+    router.navigate(destination, { replace });
+  }, [destination, replace, router]);
+
+  return null;
+};
+
+type RouteProps = {
+  path?: string;
+  element?: ReactNode;
+  index?: boolean;
+  children?: ReactNode;
+};
+
+const Route = (_props: RouteProps) => null;
+
+type RoutesProps = { children?: ReactNode };
+
+type RouteElement = ReactElement<RouteProps>;
+
+const matchRoute = (
+  element: RouteElement,
+  basePath: string,
+  pathname: string,
+  isFallback = false
+): ReactNode | null => {
+  const { path, index, element: component, children } = element.props;
+  const normalizedBase = normalizePath(basePath);
+
+  if (index) {
+    if (normalizePath(pathname) !== normalizedBase) {
+      return null;
+    }
+  } else if (!isFallback) {
+    if (!path) {
+      return null;
+    }
+    const target = resolvePath(path, basePath);
+    const normalizedTarget = normalizePath(target);
+    const normalizedLocation = normalizePath(pathname);
+    const hasChildren = Children.count(children) > 0;
+    const exactMatch = normalizedLocation === normalizedTarget;
+    const partialMatch = hasChildren && normalizedLocation.startsWith(`${normalizedTarget}/`);
+    if (!exactMatch && !partialMatch) {
+      return null;
+    }
+  }
+
+  const routeBase = index ? normalizedBase : path && path !== "*" ? resolvePath(path, basePath) : normalizedBase;
+  const outlet = children ? (
+    <RouteContext.Provider value={{ basePath: routeBase }}>
+      <Routes>{children}</Routes>
+    </RouteContext.Provider>
+  ) : null;
+
+  return (
+    <RouteContext.Provider value={{ basePath: routeBase }}>
+      <OutletContext.Provider value={outlet}>{component ?? outlet}</OutletContext.Provider>
+    </RouteContext.Provider>
+  );
+};
+
+export const Routes = ({ children }: RoutesProps) => {
+  const { location } = useRouter();
+  const { basePath } = useRouteContext();
+  const entries = Children.toArray(children).filter(isValidElement) as RouteElement[];
+
+  let fallback: RouteElement | null = null;
+
+  for (const entry of entries) {
+    if (entry.props.path === "*") {
+      fallback = entry;
+      continue;
+    }
+    const match = matchRoute(entry, basePath, location.pathname);
+    if (match) {
+      return <>{match}</>;
+    }
+  }
+
+  if (fallback) {
+    return <>{matchRoute(fallback, basePath, location.pathname, true)}</>;
+  }
+
+  return null;
+};
+
+type RouterProps = { children?: ReactNode };
+
+type HistoryRouterProps = RouterProps & {
+  getCurrentLocation: () => LocationShape;
+  pushLocation: (to: string, replace?: boolean) => string;
+  listen: (listener: () => void) => () => void;
+};
+
+const HistoryRouter = ({ children, getCurrentLocation, pushLocation, listen }: HistoryRouterProps) => {
+  const [location, setLocation] = useState<LocationShape>(() => getCurrentLocation());
+
+  useEffect(() => listen(() => setLocation(getCurrentLocation())), [getCurrentLocation, listen]);
+
+  const navigate = useCallback(
+    (to: string, options?: { replace?: boolean }) => {
+      const next = pushLocation(normalizePath(to), options?.replace);
+      setLocation({ pathname: next });
+    },
+    [pushLocation]
+  );
+
+  const contextValue = useMemo<RouterContextValue>(() => ({ location, navigate }), [location, navigate]);
+
+  return (
+    <RouterContext.Provider value={contextValue}>
+      <RouteContext.Provider value={{ basePath: "/" }}>{children}</RouteContext.Provider>
+    </RouterContext.Provider>
+  );
+};
+
+export const BrowserRouter = ({ children }: RouterProps) => {
+  if (typeof window === "undefined") {
+    return (
+      <HistoryRouter
+        getCurrentLocation={() => ({ pathname: "/" })}
+        pushLocation={(to) => to}
+        listen={() => () => void 0}
+      >
+        {children}
+      </HistoryRouter>
+    );
+  }
+
+  const getCurrentLocation = () => ({ pathname: normalizePath(window.location.pathname || "/") });
+  const pushLocation = (to: string, replace?: boolean) => {
+    if (replace) {
+      window.history.replaceState(null, "", to);
+    } else {
+      window.history.pushState(null, "", to);
+    }
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    return normalizePath(to);
+  };
+  const listen = (listener: () => void) => {
+    window.addEventListener("popstate", listener);
+    return () => window.removeEventListener("popstate", listener);
+  };
+
+  return (
+    <HistoryRouter getCurrentLocation={getCurrentLocation} pushLocation={pushLocation} listen={listen}>
+      {children}
+    </HistoryRouter>
+  );
+};
+
+type MemoryRouterProps = RouterProps & { initialEntries?: string[] };
+
+export const MemoryRouter = ({ initialEntries, children }: MemoryRouterProps) => {
+  const entries = initialEntries && initialEntries.length ? initialEntries : ["/"];
+  const [locations, setLocations] = useState(() => entries.map((entry) => normalizePath(entry)));
+  const [index, setIndex] = useState(() => Math.min(entries.length - 1, 0));
+
+  const getCurrentLocation = () => ({ pathname: locations[Math.min(index, locations.length - 1)] });
+  const pushLocation = (to: string, replace?: boolean) => {
+    const next = normalizePath(to);
+    setLocations((prev) => {
+      if (replace) {
+        const copy = [...prev];
+        copy[Math.min(index, copy.length - 1)] = next;
+        return copy;
+      }
+      const prefix = prev.slice(0, Math.min(index, prev.length - 1) + 1);
+      return [...prefix, next];
+    });
+    setIndex((prev) => (replace ? prev : prev + 1));
+    return next;
+  };
+  const listen = (_listener: () => void) => () => void 0;
+
+  return (
+    <HistoryRouter getCurrentLocation={getCurrentLocation} pushLocation={pushLocation} listen={listen}>
+      {children}
+    </HistoryRouter>
+  );
+};
+
+export { Route };
+export type { RouteProps };

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,113 @@
+export type SupabaseRole = "admin" | "client";
+
+export type SupabaseProfile = {
+  id: string;
+  role: SupabaseRole;
+  email: string;
+  label: string;
+};
+
+type AuthListener = (event: "SIGNED_IN" | "SIGNED_OUT", session: { user: { id: string } | null }) => void;
+
+type SingleResponse<T> = Promise<{ data: T | null; error: Error | null }>;
+
+const demoProfiles: SupabaseProfile[] = [
+  {
+    id: "admin-0001",
+    role: "admin",
+    email: "amelie@aeditus.app",
+    label: "Amélie · Admin",
+  },
+  {
+    id: "client-0001",
+    role: "client",
+    email: "marc@atelierverne.fr",
+    label: "Marc · Client",
+  },
+];
+
+let activeUserId: string | null = typeof window !== "undefined" ? window.localStorage.getItem("aeditus.activeUser") : null;
+const listeners = new Set<AuthListener>();
+
+function notify(event: "SIGNED_IN" | "SIGNED_OUT") {
+  const session = activeUserId ? { user: { id: activeUserId } } : { user: null };
+  listeners.forEach((listener) => listener(event, session));
+}
+
+function persist(id: string | null) {
+  if (typeof window === "undefined") return;
+  if (id) {
+    window.localStorage.setItem("aeditus.activeUser", id);
+  } else {
+    window.localStorage.removeItem("aeditus.activeUser");
+  }
+}
+
+function resolveProfile(id: string | null) {
+  if (!id) return null;
+  return demoProfiles.find((profile) => profile.id === id) ?? null;
+}
+
+function selectProfile(role?: SupabaseRole) {
+  const profile = resolveProfile(activeUserId);
+  if (!profile) return null;
+  if (role && profile.role !== role) return null;
+  return profile;
+}
+
+function makeTableClient(table: string) {
+  return {
+    select(_columns?: string) {
+      return {
+        single(): SingleResponse<{ role: SupabaseRole }> {
+          if (table !== "profiles") {
+            return Promise.resolve({ data: null, error: new Error(`Table "${table}" non supportée en mode démo.`) });
+          }
+          const profile = selectProfile();
+          if (!profile) {
+            return Promise.resolve({ data: null, error: new Error("Aucun profil actif.") });
+          }
+          return Promise.resolve({ data: { role: profile.role }, error: null });
+        },
+      };
+    },
+  };
+}
+
+export const supabase = {
+  auth: {
+    async getUser() {
+      const profile = resolveProfile(activeUserId);
+      return { data: { user: profile ? { id: profile.id } : null } };
+    },
+    onAuthStateChange(callback: AuthListener) {
+      listeners.add(callback);
+      return {
+        data: {
+          subscription: {
+            unsubscribe() {
+              listeners.delete(callback);
+            },
+          },
+        },
+      };
+    },
+  },
+  from(table: string) {
+    return makeTableClient(table);
+  },
+};
+
+export function listDemoProfiles() {
+  return demoProfiles.slice();
+}
+
+export function setActiveProfile(id: string | null) {
+  activeUserId = id;
+  persist(id);
+  notify(id ? "SIGNED_IN" : "SIGNED_OUT");
+}
+
+export function getActiveProfile() {
+  return resolveProfile(activeUserId);
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...inputs: Array<string | false | null | undefined>) {
+  return inputs.filter(Boolean).join(" ");
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,12 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { QueryClient, QueryClientProvider } from "@/lib/query";
 
-createRoot(document.getElementById("root")!).render(<App />);
+const queryClient = new QueryClient();
+
+createRoot(document.getElementById("root")!).render(
+  <QueryClientProvider client={queryClient}>
+    <App />
+  </QueryClientProvider>
+);

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+
+const NotFound = () => (
+  <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-subtle px-4 text-center">
+    <div className="space-y-4 rounded-3xl border bg-card p-10 shadow-gold">
+      <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary">404</p>
+      <h1 className="text-3xl font-semibold">Page introuvable</h1>
+      <p className="max-w-md text-sm text-muted-foreground">
+        Cette URL n'existe pas (encore). Utilisez la navigation ou retournez sur la page d'accueil pour explorer la démo Æditus.
+      </p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+        <Link className="rounded-xl bg-primary px-5 py-2 text-sm font-medium text-primary-foreground" to="/">
+          Revenir à la landing
+        </Link>
+        <Link className="rounded-xl border px-5 py-2 text-sm font-medium" to="/app">
+          Explorer l'espace client
+        </Link>
+      </div>
+    </div>
+  </div>
+);
+
+export default NotFound;

--- a/src/pages/admin/Billing.tsx
+++ b/src/pages/admin/Billing.tsx
@@ -1,0 +1,70 @@
+const invoices = [
+  { id: "INV-2025-091", customer: "Atelier Verne", amount: "179 €", status: "Payée" },
+  { id: "INV-2025-092", customer: "Maison Ondine", amount: "399 €", status: "En cours" },
+  { id: "INV-2025-093", customer: "Studio Rive", amount: "79 €", status: "Payée" },
+];
+
+const AdminBilling = () => (
+  <div className="space-y-6">
+    <section className="rounded-2xl border bg-card p-6 shadow-elegant">
+      <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-lg font-semibold">Facturation Stripe</h1>
+          <p className="text-sm text-muted-foreground">
+            Pilotez les abonnements Essential/Starter/Pro, add-ons Fynk et exclusivités avec le mode test activé.
+          </p>
+        </div>
+        <button className="rounded-xl border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-medium text-primary">
+          Ouvrir le dashboard Stripe
+        </button>
+      </header>
+
+      <div className="mt-4 grid gap-4 md:grid-cols-3">
+        <article className="rounded-xl border bg-background p-4">
+          <p className="text-xs text-muted-foreground">MRR (test)</p>
+          <p className="mt-2 text-2xl font-semibold">{"1\u202f986 €"}</p>
+        </article>
+        <article className="rounded-xl border bg-background p-4">
+          <p className="text-xs text-muted-foreground">Add-ons actifs</p>
+          <p className="mt-2 text-2xl font-semibold">14 Fynk · 6 Ambassadeurs</p>
+        </article>
+        <article className="rounded-xl border bg-background p-4">
+          <p className="text-xs text-muted-foreground">Paiements en échec</p>
+          <p className="mt-2 text-2xl font-semibold">0</p>
+        </article>
+      </div>
+    </section>
+
+    <section className="rounded-2xl border bg-card p-6 shadow-elegant">
+      <h2 className="text-base font-semibold">Historique des factures</h2>
+      <div className="mt-4 overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th className="px-3 py-2 font-medium">#</th>
+              <th className="px-3 py-2 font-medium">Client</th>
+              <th className="px-3 py-2 font-medium">Montant</th>
+              <th className="px-3 py-2 font-medium">Statut</th>
+            </tr>
+          </thead>
+          <tbody>
+            {invoices.map((invoice) => (
+              <tr key={invoice.id} className="border-t border-border/60">
+                <td className="px-3 py-2 font-medium">{invoice.id}</td>
+                <td className="px-3 py-2">{invoice.customer}</td>
+                <td className="px-3 py-2">{invoice.amount}</td>
+                <td className="px-3 py-2">
+                  <span className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+                    {invoice.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+);
+
+export default AdminBilling;

--- a/src/pages/admin/Clients.tsx
+++ b/src/pages/admin/Clients.tsx
@@ -1,0 +1,82 @@
+const clients = [
+  {
+    name: "Atelier Verne",
+    plan: "Starter",
+    health: "vert",
+    contents: 48,
+    manager: "Marc",
+  },
+  {
+    name: "Maison Ondine",
+    plan: "Pro",
+    health: "ambre",
+    contents: 92,
+    manager: "Julie",
+  },
+  {
+    name: "Club Ambassadeurs",
+    plan: "Essential",
+    health: "vert",
+    contents: 16,
+    manager: "Lucas",
+  },
+];
+
+const AdminClients = () => (
+  <div className="rounded-2xl border bg-card p-6 shadow-elegant">
+    <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h1 className="text-lg font-semibold">Clients & quotas</h1>
+        <p className="text-sm text-muted-foreground">
+          Visualisez les plans, add-ons Fynk/Ambassadeurs et la consommation des quotas contenus.
+        </p>
+      </div>
+      <button className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-gold">
+        Ajouter un client
+      </button>
+    </header>
+
+    <div className="mt-6 overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left text-muted-foreground">
+            <th className="px-3 py-2 font-medium">Organisation</th>
+            <th className="px-3 py-2 font-medium">Plan</th>
+            <th className="px-3 py-2 font-medium">Quota utilisé</th>
+            <th className="px-3 py-2 font-medium">CSM</th>
+            <th className="px-3 py-2 font-medium">Statut</th>
+          </tr>
+        </thead>
+        <tbody>
+          {clients.map((client) => (
+            <tr key={client.name} className="border-t border-border/60">
+              <td className="px-3 py-3 font-medium">{client.name}</td>
+              <td className="px-3 py-3">{client.plan}</td>
+              <td className="px-3 py-3">
+                <div className="flex items-center gap-3">
+                  <div className="h-2 flex-1 rounded-full bg-muted">
+                    <span
+                      className="block h-full rounded-full bg-primary"
+                      style={{ width: `${Math.min(100, client.contents)}%` }}
+                    />
+                  </div>
+                  <span>{client.contents} contenus</span>
+                </div>
+              </td>
+              <td className="px-3 py-3 text-muted-foreground">{client.manager}</td>
+              <td className="px-3 py-3">
+                <span
+                  className="inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide"
+                >
+                  {client.health === "vert" ? "Actif" : "À surveiller"}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </div>
+);
+
+export default AdminClients;

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -1,0 +1,70 @@
+const metrics = [
+  { label: "Tenants actifs", value: "32", delta: "+5 cette semaine" },
+  { label: "Contenus générés", value: "486", delta: "92% automatisé" },
+  { label: "Taux approbation", value: "87%", delta: "Clients satisfaits" },
+];
+
+const workflows = [
+  {
+    name: "SEO Pipeline",
+    status: "Opérationnel",
+    description: "n8n → OpenAI → Postiz",
+    badge: "Realtime",
+  },
+  {
+    name: "Facturation Stripe",
+    status: "Sync",
+    description: "Abonnements + add-ons",
+    badge: "Audité",
+  },
+  {
+    name: "Sandbox QA",
+    status: "Tests en cours",
+    description: "Contenus fictifs + Postiz brouillon",
+    badge: "Pré-prod",
+  },
+];
+
+const AdminDashboard = () => (
+  <div className="space-y-6">
+    <section className="grid gap-4 md:grid-cols-3">
+      {metrics.map((metric) => (
+        <article key={metric.label} className="rounded-2xl border bg-card p-4 shadow-elegant">
+          <p className="text-sm text-muted-foreground">{metric.label}</p>
+          <p className="mt-3 text-3xl font-semibold">{metric.value}</p>
+          <p className="mt-1 text-xs uppercase tracking-wide text-primary">{metric.delta}</p>
+        </article>
+      ))}
+    </section>
+
+    <section className="rounded-2xl border bg-card p-6 shadow-elegant">
+      <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Workflows critiques</h2>
+          <p className="text-sm text-muted-foreground">
+            Surveillez les intégrations n8n, Stripe et Postiz pour garantir la continuité de service.
+          </p>
+        </div>
+        <button className="rounded-xl border border-primary/40 bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+          Ouvrir n8n Cloud
+        </button>
+      </header>
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        {workflows.map((item) => (
+          <article key={item.name} className="rounded-xl border bg-background p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-base font-semibold">{item.name}</h3>
+              <span className="rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-primary">
+                {item.badge}
+              </span>
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">{item.description}</p>
+            <p className="mt-3 text-xs font-medium text-emerald-600 dark:text-emerald-400">{item.status}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  </div>
+);
+
+export default AdminDashboard;

--- a/src/pages/admin/Integrations.tsx
+++ b/src/pages/admin/Integrations.tsx
@@ -1,0 +1,56 @@
+const integrations = [
+  {
+    name: "Stripe Billing",
+    status: "Connecté",
+    description: "Paiements, abonnements & factures automatiques",
+  },
+  {
+    name: "n8n Cloud",
+    status: "Webhook OK",
+    description: "Orchestration génération IA & monitoring",
+  },
+  {
+    name: "Postiz",
+    status: "File d'attente",
+    description: "Publication jusqu'à 20 réseaux avec retries",
+  },
+  {
+    name: "WordPress",
+    status: "Connecteur",
+    description: "Publication articles + SEO schema",
+  },
+];
+
+const AdminIntegrations = () => (
+  <div className="rounded-2xl border bg-card p-6 shadow-elegant">
+    <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <div>
+        <h1 className="text-lg font-semibold">Intégrations critiques</h1>
+        <p className="text-sm text-muted-foreground">
+          Vérifiez les connecteurs Stripe, Postiz, WordPress, Replicate/Fal.ai et configurez les clés API par tenant.
+        </p>
+      </div>
+      <button className="rounded-xl border bg-background px-4 py-2 text-sm shadow-sm hover:bg-muted">
+        Ajouter une intégration
+      </button>
+    </header>
+    <ul className="mt-6 grid gap-4 md:grid-cols-2">
+      {integrations.map((integration) => (
+        <li key={integration.name} className="rounded-xl border bg-background p-4">
+          <header className="flex items-center justify-between">
+            <h2 className="text-base font-semibold">{integration.name}</h2>
+            <span className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+              {integration.status}
+            </span>
+          </header>
+          <p className="mt-2 text-sm text-muted-foreground">{integration.description}</p>
+          <button className="mt-4 text-sm font-medium text-primary underline-offset-4 hover:underline">
+            Tester la connexion
+          </button>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default AdminIntegrations;

--- a/src/pages/admin/Roadmaps.tsx
+++ b/src/pages/admin/Roadmaps.tsx
@@ -1,0 +1,64 @@
+const roadmapRows = [
+  {
+    feature: "Mode Sandbox complet",
+    status: "En test",
+    impact: "QA",
+    votes: 18,
+  },
+  {
+    feature: "Exports PowerPoint",
+    status: "Prévu",
+    impact: "Customer Success",
+    votes: 26,
+  },
+  {
+    feature: "Copilot Alfie multilingue",
+    status: "Livré",
+    impact: "AI",
+    votes: 42,
+  },
+];
+
+const AdminRoadmaps = () => (
+  <div className="space-y-4">
+    <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <div>
+        <h1 className="text-lg font-semibold">Roadmap publique & feedback</h1>
+        <p className="text-sm text-muted-foreground">
+          Synchronisez les suggestions clients, votes et statuts pour piloter la roadmap visible depuis la plateforme.
+        </p>
+      </div>
+      <button className="rounded-xl border bg-background px-4 py-2 text-sm shadow-sm hover:bg-muted">
+        Exporter en CSV
+      </button>
+    </header>
+
+    <section className="overflow-hidden rounded-2xl border bg-card">
+      <div className="hidden border-b bg-muted/40 px-6 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid md:grid-cols-[2fr_1fr_1fr_80px]">
+        <span>Feature</span>
+        <span>Impact</span>
+        <span>Statut</span>
+        <span>Votes</span>
+      </div>
+      <ul className="divide-y divide-border/70">
+        {roadmapRows.map((row) => (
+          <li key={row.feature} className="grid gap-3 px-6 py-4 text-sm md:grid-cols-[2fr_1fr_1fr_80px]">
+            <div>
+              <p className="font-semibold">{row.feature}</p>
+              <p className="text-xs text-muted-foreground">Aligné avec les besoins SEO & social automation.</p>
+            </div>
+            <span className="self-center rounded-full border px-3 py-1 text-xs uppercase tracking-wide text-muted-foreground">
+              {row.impact}
+            </span>
+            <span className="self-center rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+              {row.status}
+            </span>
+            <span className="self-center text-right text-base font-semibold">{row.votes}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  </div>
+);
+
+export default AdminRoadmaps;

--- a/src/pages/admin/Settings.tsx
+++ b/src/pages/admin/Settings.tsx
@@ -1,0 +1,29 @@
+const toggles = [
+  { id: "rls", label: "Row Level Security activée", description: "Protège toutes les tables Supabase par tenant." },
+  { id: "sandbox", label: "Mode Sandbox", description: "Génère contenus fictifs et paiements Stripe test." },
+  { id: "copilot", label: "Alfie Copilot", description: "Disponible pour tous les forfaits client." },
+];
+
+const AdminSettings = () => (
+  <div className="rounded-2xl border bg-card p-6 shadow-elegant">
+    <h1 className="text-lg font-semibold">Paramètres généraux</h1>
+    <p className="mt-1 text-sm text-muted-foreground">
+      Configurez les options globales : rôles, sandbox, exports et notifications multi-canaux.
+    </p>
+    <ul className="mt-6 space-y-4">
+      {toggles.map((toggle) => (
+        <li key={toggle.id} className="flex items-start justify-between gap-4 rounded-xl border bg-background p-4">
+          <div>
+            <p className="font-medium">{toggle.label}</p>
+            <p className="text-sm text-muted-foreground">{toggle.description}</p>
+          </div>
+          <button className="rounded-full border border-primary/30 bg-primary/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+            Activé
+          </button>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default AdminSettings;

--- a/src/pages/app/Discussions.tsx
+++ b/src/pages/app/Discussions.tsx
@@ -1,0 +1,45 @@
+const threads = [
+  {
+    title: "Brief vidéo HERO",
+    author: "Amélie (Æditus)",
+    excerpt: "Nous avons intégré les retours du board, prêt pour validation.",
+    timestamp: "Il y a 3h",
+  },
+  {
+    title: "Stratégie Reels Octobre",
+    author: "Marc",
+    excerpt: "Peut-on ajouter un accent ambassadeurs pour LinkedIn ?",
+    timestamp: "Hier",
+  },
+];
+
+const ClientDiscussions = () => (
+  <div className="rounded-2xl border bg-card p-6 shadow-elegant">
+    <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <div>
+        <h1 className="text-lg font-semibold">Discussions & support</h1>
+        <p className="text-sm text-muted-foreground">
+          Alfie centralise vos échanges, les décisions et ouvre un ticket si besoin côté admin.
+        </p>
+      </div>
+      <button className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-gold">
+        Nouvelle discussion
+      </button>
+    </header>
+
+    <ul className="mt-6 space-y-3">
+      {threads.map((thread) => (
+        <li key={thread.title} className="rounded-xl border bg-background p-4">
+          <header className="flex items-center justify-between">
+            <p className="font-medium">{thread.title}</p>
+            <span className="text-xs text-muted-foreground">{thread.timestamp}</span>
+          </header>
+          <p className="mt-1 text-xs text-muted-foreground">{thread.author}</p>
+          <p className="mt-2 text-sm text-foreground">{thread.excerpt}</p>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default ClientDiscussions;

--- a/src/pages/app/Files.tsx
+++ b/src/pages/app/Files.tsx
@@ -1,0 +1,35 @@
+const assets = [
+  { name: "Article - Stratégie SEO Q4", type: "Google Doc", size: "28 ko" },
+  { name: "Visuels Carrousel IG", type: "Zip", size: "12 Mo" },
+  { name: "Video HERO 4K", type: "MP4", size: "320 Mo" },
+];
+
+const ClientFiles = () => (
+  <div className="rounded-2xl border bg-card p-6 shadow-elegant">
+    <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <div>
+        <h1 className="text-lg font-semibold">Livrables</h1>
+        <p className="text-sm text-muted-foreground">
+          Retrouvez tous vos contenus générés, classés par campagne et prêts au téléchargement.
+        </p>
+      </div>
+      <button className="rounded-xl border bg-background px-4 py-2 text-sm shadow-sm hover:bg-muted">
+        Importer un fichier
+      </button>
+    </header>
+
+    <ul className="mt-6 grid gap-4 md:grid-cols-3">
+      {assets.map((asset) => (
+        <li key={asset.name} className="rounded-xl border bg-background p-4">
+          <p className="font-medium">{asset.name}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{asset.type} · {asset.size}</p>
+          <button className="mt-4 text-sm font-medium text-primary underline-offset-4 hover:underline">
+            Télécharger
+          </button>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default ClientFiles;

--- a/src/pages/app/Overview.tsx
+++ b/src/pages/app/Overview.tsx
@@ -1,0 +1,53 @@
+const highlights = [
+  {
+    title: "Plan éditorial",
+    description: "12 articles SEO + 36 déclinaisons social déjà prêts pour validation.",
+  },
+  {
+    title: "Visuels & vidéos",
+    description: "Replicate / Fal.ai livrent 18 visuels + 4 vidéos HÉRO.",
+  },
+  {
+    title: "Performance",
+    description: "+32% clics vs mois précédent, Instagram ER 5.4%.",
+  },
+];
+
+const ClientOverview = () => (
+  <div className="space-y-6">
+    <section className="rounded-2xl border bg-card p-6 shadow-gold">
+      <h1 className="text-2xl font-semibold">Bonjour Marc 👋</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Votre copilot Alfie a généré le prochain cycle éditorial en tenant compte des tendances AI Overviews et mobiles.
+      </p>
+      <div className="mt-6 grid gap-4 md:grid-cols-3">
+        {highlights.map((highlight) => (
+          <article key={highlight.title} className="rounded-xl border bg-background p-4">
+            <p className="text-sm font-medium text-primary uppercase tracking-wide">{highlight.title}</p>
+            <p className="mt-2 text-sm text-muted-foreground">{highlight.description}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+
+    <section className="rounded-2xl border bg-card p-6 shadow-elegant">
+      <h2 className="text-lg font-semibold">Actions rapides</h2>
+      <div className="mt-4 grid gap-4 md:grid-cols-3">
+        <button className="rounded-xl border bg-background px-4 py-6 text-left text-sm font-medium shadow-sm transition hover:-translate-y-0.5 hover:shadow-gold">
+          Valider le plan éditorial
+          <span className="mt-1 block text-xs font-normal text-muted-foreground">12 contenus en attente</span>
+        </button>
+        <button className="rounded-xl border bg-background px-4 py-6 text-left text-sm font-medium shadow-sm transition hover:-translate-y-0.5 hover:shadow-gold">
+          Activer Fynk Engagement
+          <span className="mt-1 block text-xs font-normal text-muted-foreground">400 interactions incluses</span>
+        </button>
+        <button className="rounded-xl border bg-background px-4 py-6 text-left text-sm font-medium shadow-sm transition hover:-translate-y-0.5 hover:shadow-gold">
+          Consulter les KPI détaillés
+          <span className="mt-1 block text-xs font-normal text-muted-foreground">Exports CSV · PDF · PPT</span>
+        </button>
+      </div>
+    </section>
+  </div>
+);
+
+export default ClientOverview;

--- a/src/pages/app/Roadmap.tsx
+++ b/src/pages/app/Roadmap.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useState } from "react";
+
+const kanbanColumns = [
+  {
+    name: "Backlog",
+    items: ["Études AI Overviews", "Landing page Fynk"],
+  },
+  {
+    name: "En cours",
+    items: ["Calendrier éditorial Octobre", "Série Reels 9:16"],
+  },
+  {
+    name: "Prêt", 
+    items: ["Newsletter premium", "Vidéo HERO studio"],
+  },
+];
+
+const timeline = [
+  { date: "Semaine 38", task: "Validation plan + assets visuels" },
+  { date: "Semaine 39", task: "Programmation Postiz multi-réseaux" },
+  { date: "Semaine 40", task: "Analyse KPI + recommandations" },
+];
+
+const tableRows = [
+  { type: "Article", owner: "Æditus", status: "À valider", slot: "17 sept." },
+  { type: "Reel IG", owner: "Æditus", status: "Planifié", slot: "19 sept." },
+  { type: "Post LinkedIn", owner: "Client", status: "Brouillon", slot: "20 sept." },
+];
+
+const views = [
+  { id: "kanban", label: "Kanban" },
+  { id: "timeline", label: "Timeline" },
+  { id: "table", label: "Table" },
+] as const;
+
+type ViewId = (typeof views)[number]["id"];
+
+const ClientRoadmap = () => {
+  const [view, setView] = useState<ViewId>(() => {
+    if (typeof window !== "undefined") {
+      const saved = window.localStorage.getItem("aeditus.roadmap-view");
+      if (saved === "timeline" || saved === "table") return saved;
+    }
+    return "kanban";
+  });
+
+  const handleViewChange = (next: ViewId) => {
+    setView(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("aeditus.roadmap-view", next);
+    }
+  };
+
+  const content = useMemo(() => {
+    switch (view) {
+      case "kanban":
+        return (
+          <div className="grid gap-4 md:grid-cols-3">
+            {kanbanColumns.map((column) => (
+              <section key={column.name} className="rounded-2xl border bg-background p-4">
+                <header className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                    {column.name}
+                  </h3>
+                  <span className="text-xs text-muted-foreground">{column.items.length}</span>
+                </header>
+                <ul className="mt-3 space-y-3">
+                  {column.items.map((item) => (
+                    <li key={item} className="rounded-xl border bg-card px-3 py-2 text-sm shadow-sm">
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+        );
+      case "timeline":
+        return (
+          <ol className="relative space-y-6 border-l border-dashed border-primary/40 pl-6">
+            {timeline.map((entry) => (
+              <li key={entry.date} className="relative">
+                <span className="absolute -left-3 top-1.5 h-2.5 w-2.5 rounded-full border border-primary/50 bg-primary/10" />
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{entry.date}</p>
+                <p className="text-sm text-foreground">{entry.task}</p>
+              </li>
+            ))}
+          </ol>
+        );
+      case "table":
+        return (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-muted-foreground">
+                  <th className="px-3 py-2 font-medium">Type</th>
+                  <th className="px-3 py-2 font-medium">Responsable</th>
+                  <th className="px-3 py-2 font-medium">Statut</th>
+                  <th className="px-3 py-2 font-medium">Créneau</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tableRows.map((row) => (
+                  <tr key={`${row.type}-${row.slot}`} className="border-t border-border/60">
+                    <td className="px-3 py-2 font-medium">{row.type}</td>
+                    <td className="px-3 py-2">{row.owner}</td>
+                    <td className="px-3 py-2">
+                      <span className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs uppercase tracking-wide text-primary">
+                        {row.status}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2">{row.slot}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
+      default:
+        return null;
+    }
+  }, [view]);
+
+  return (
+    <div className="space-y-4">
+      <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-lg font-semibold">Roadmap éditoriale</h1>
+          <p className="text-sm text-muted-foreground">
+            Kanban, timeline ou table : choisissez votre vue, glissez-déposez et laissez Alfie recalculer les quotas.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 rounded-full border bg-background p-1 text-xs">
+          {views.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => handleViewChange(item.id)}
+              className={`rounded-full px-3 py-1 transition ${
+                view === item.id ? "bg-primary text-primary-foreground" : "hover:bg-muted"
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </header>
+      <div className="rounded-2xl border bg-card p-6 shadow-elegant">{content}</div>
+    </div>
+  );
+};
+
+export default ClientRoadmap;

--- a/src/pages/app/Settings.tsx
+++ b/src/pages/app/Settings.tsx
@@ -1,0 +1,29 @@
+const toggles = [
+  { id: "autoschedule", label: "Auto-planification", description: "Remplir automatiquement les créneaux libres." },
+  { id: "notifications", label: "Notifications multicanaux", description: "Email + Slack + WhatsApp." },
+  { id: "alfie", label: "Suggestions Alfie", description: "Titres, formats, timing optimisé." },
+];
+
+const ClientSettings = () => (
+  <div className="rounded-2xl border bg-card p-6 shadow-elegant">
+    <h1 className="text-lg font-semibold">Paramètres du workspace</h1>
+    <p className="mt-1 text-sm text-muted-foreground">
+      Ajustez vos préférences : automations, notifications, accès équipe et export KPI.
+    </p>
+    <ul className="mt-6 space-y-3">
+      {toggles.map((toggle) => (
+        <li key={toggle.id} className="flex items-center justify-between rounded-xl border bg-background p-4">
+          <div>
+            <p className="font-medium">{toggle.label}</p>
+            <p className="text-xs text-muted-foreground">{toggle.description}</p>
+          </div>
+          <button className="rounded-full border border-primary/30 bg-primary/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+            Activé
+          </button>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default ClientSettings;

--- a/src/pages/app/Tasks.tsx
+++ b/src/pages/app/Tasks.tsx
@@ -1,0 +1,40 @@
+const tasks = [
+  { title: "Valider 5 accroches SEO", owner: "Client", due: "17 sept.", status: "À faire" },
+  { title: "Uploader assets branding", owner: "Client", due: "18 sept.", status: "En cours" },
+  { title: "Review vidéo HERO", owner: "Æditus", due: "19 sept.", status: "En attente" },
+];
+
+const ClientTasks = () => (
+  <div className="rounded-2xl border bg-card p-6 shadow-elegant">
+    <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <div>
+        <h1 className="text-lg font-semibold">Tâches collaboratives</h1>
+        <p className="text-sm text-muted-foreground">
+          Vos actions et celles de l'équipe Æditus apparaissent ici avec suivi temps réel.
+        </p>
+      </div>
+      <button className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-gold">
+        Créer une tâche
+      </button>
+    </header>
+
+    <ul className="mt-6 space-y-3">
+      {tasks.map((task) => (
+        <li key={task.title} className="flex flex-col gap-3 rounded-xl border bg-background p-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="font-medium">{task.title}</p>
+            <p className="text-xs text-muted-foreground">Responsable : {task.owner}</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+              {task.status}
+            </span>
+            <span className="text-sm text-muted-foreground">Pour le {task.due}</span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default ClientTasks;

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -1,0 +1,35 @@
+import { listDemoProfiles, setActiveProfile } from "@/lib/supabaseClient";
+
+const Login = () => (
+  <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-subtle px-4 py-16">
+    <div className="w-full max-w-md space-y-6 rounded-3xl border bg-card p-8 shadow-gold">
+      <div className="space-y-2 text-center">
+        <p className="text-sm font-medium uppercase tracking-wide text-primary">Æditus Sandbox</p>
+        <h1 className="text-2xl font-semibold">Connexion démo</h1>
+        <p className="text-sm text-muted-foreground">
+          Sélectionnez un rôle pour explorer la plateforme. Les comptes réels utilisent Supabase Auth + RLS.
+        </p>
+      </div>
+      <div className="space-y-3">
+        {listDemoProfiles().map((profile) => (
+          <button
+            key={profile.id}
+            className="w-full rounded-xl border bg-background px-4 py-3 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-gold"
+            onClick={() => setActiveProfile(profile.id)}
+          >
+            <p className="font-medium">{profile.label}</p>
+            <p className="text-xs text-muted-foreground">{profile.email}</p>
+          </button>
+        ))}
+        <button
+          className="w-full rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
+          onClick={() => setActiveProfile(null)}
+        >
+          Se déconnecter
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+export default Login;

--- a/supabase/migrations/0001_create_profiles.sql
+++ b/supabase/migrations/0001_create_profiles.sql
@@ -1,0 +1,21 @@
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.profiles (
+  id uuid primary key references auth.users (id) on delete cascade,
+  role text not null check (role in ('admin', 'client')) default 'client',
+  created_at timestamp with time zone default timezone('utc', now())
+);
+
+alter table public.profiles enable row level security;
+
+create policy if not exists "profiles_read_own" on public.profiles
+  for select using (auth.uid() = id);
+
+create policy if not exists "profiles_update_own" on public.profiles
+  for update using (auth.uid() = id);
+
+create policy if not exists "profiles_admin_full_access" on public.profiles
+  for all using (exists (
+    select 1 from public.profiles as p
+    where p.id = auth.uid() and p.role = 'admin'
+  ));

--- a/supabase/seed/profiles.sql
+++ b/supabase/seed/profiles.sql
@@ -1,0 +1,5 @@
+insert into public.profiles (id, role)
+values
+  ('00000000-0000-4000-8000-000000000001', 'admin'),
+  ('00000000-0000-4000-8000-000000000002', 'client')
+  on conflict (id) do update set role = excluded.role;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -80,6 +80,7 @@ export default {
         'bounce': 'var(--transition-bounce)',
       },
       borderRadius: {
+        "2xl": "var(--radius)",
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",

--- a/tests/landing.spec.tsx
+++ b/tests/landing.spec.tsx
@@ -1,11 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import NewLandingPage, { calc } from '@/components/landing/NewLandingPage';
 
 describe('NewLandingPage', () => {
   it('affiche le hero et oriente les CTA vers les offres', () => {
-    render(<NewLandingPage />);
+    render(
+      <MemoryRouter>
+        <NewLandingPage />
+      </MemoryRouter>
+    );
 
     expect(
       screen.getByText(/plan éditorial mensuel & calendrier de publication/i),
@@ -16,10 +21,17 @@ describe('NewLandingPage', () => {
     ctas.forEach((cta) => {
       expect(cta).toHaveAttribute('href', '#offres');
     });
+
+    expect(screen.getByRole('link', { name: /Explorer la plateforme/i })).toHaveAttribute('href', '/app');
+    expect(screen.getByRole('link', { name: /Voir la plateforme/i })).toHaveAttribute('href', '/app');
   });
 
   it('bascule vers la tarification annuelle', () => {
-    render(<NewLandingPage />);
+    render(
+      <MemoryRouter>
+        <NewLandingPage />
+      </MemoryRouter>
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Annuel' }));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "paths": {
       "@/*": ["./src/*"],
       "framer-motion": ["./src/compat/framer-motion"],
-      "framer-motion/*": ["./src/compat/framer-motion"]
+      "framer-motion/*": ["./src/compat/framer-motion"],
+      "react-router-dom": ["./src/lib/router"],
+      "react-router-dom/*": ["./src/lib/router"]
     },
     "noImplicitAny": false,
     "noUnusedParameters": false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
       "framer-motion": fileURLToPath(new URL("./src/compat/framer-motion.tsx", import.meta.url)),
+      "react-router-dom": fileURLToPath(new URL("./src/lib/router.tsx", import.meta.url)),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- remove the leaked .env, harden the ignore rules, and add Supabase RBAC SQL assets
- replace the single platform layout with protected admin/client routes, an AppShell menu, and demo Supabase auth with a lightweight query client
- refresh the landing page CTAs with Stripe beta gating, add the new dashboards, and update CI plus design tokens for the shared UI system

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cd36ef5ab8832c8b40dee1e60e9c83