### PR TITLE
chore: remove postiz references from demo

### DIFF
--- a/src/components/landing/NewLandingPage.tsx
+++ b/src/components/landing/NewLandingPage.tsx
@@ -200,7 +200,8 @@ const featureBlocks: { title: string; description: string; bullets: string[]; ic
 const adminModules: { title: string; description: string; icon: IconType; bullets: string[] }[] = [
   {
     title: "Intégrations clés",
-    description: "Connecteurs Stripe, n8n, Postiz, WordPress, Replicate et Fal.ai en quelques minutes.",
+    description:
+      "Connecteurs Stripe, n8n, orchestrateur social, CMS headless, Replicate et Fal.ai en quelques minutes.",
     icon: Puzzle,
     bullets: [
       "Connexion guidée + test de clé/API", 
@@ -214,7 +215,7 @@ const adminModules: { title: string; description: string; icon: IconType; bullet
     icon: FlaskConical,
     bullets: [
       "Contenus fictifs (articles/images/vidéos) générés automatiquement",
-      "Simulation de publication côté Postiz (brouillons seulement)",
+      "Simulation de publication via l’orchestrateur social (brouillons seulement)",
       "Stripe en test mode avec paiements fictifs"
     ]
   },
@@ -279,7 +280,7 @@ const stackOverview: { title: string; icon: IconType; items: string[] }[] = [
       "Back & DB : Supabase (auth, stockage, fonctions)",
       "Orchestration : n8n + workers dédiés",
       "IA Texte : OpenAI, Médias : Replicate & Fal.ai",
-      "Publication : Postiz multi-réseaux + WordPress",
+      "Publication : orchestrateur multi-réseaux + CMS headless",
       "Billing : Stripe Billing, Email : SendGrid/Postmark"
     ]
   },
@@ -298,7 +299,7 @@ const stackOverview: { title: string; icon: IconType; items: string[] }[] = [
 
 const weekRoadmap: { day: string; focus: string; details: string }[] = [
   { day: "Jour 1", focus: "Auth multi-rôle + Stripe", details: "Connexion clients/admin, test du toggle annuel (-10 %)" },
-  { day: "Jour 2", focus: "n8n + Postiz", details: "Workflows génération + publication connectés" },
+  { day: "Jour 2", focus: "n8n + orchestrateur social", details: "Workflows génération + publication connectés" },
   { day: "Jour 3", focus: "Dashboard client", details: "Plan éditorial, calendrier & KPI accessibles" },
   { day: "Jour 4", focus: "Dashboard admin", details: "Tenants, intégrations & sandbox Stripe/n8n" },
   { day: "Jour 5", focus: "Affiliation", details: "Gestion des pourcentages 10 % / 15 % et tracking" },

--- a/src/components/platform/AdminConsole.tsx
+++ b/src/components/platform/AdminConsole.tsx
@@ -58,14 +58,14 @@ const connectors: Connector[] = [
     note: "Workflow vidéos — 1 retry programmé"
   },
   {
-    name: "Postiz",
+    name: "Orchestrateur social",
     status: "ok",
     mode: "Live",
     lastCheck: "il y a 10 min",
     note: "20 réseaux connectés"
   },
   {
-    name: "WordPress",
+    name: "CMS headless",
     status: "ok",
     mode: "Live",
     lastCheck: "il y a 45 min",
@@ -281,7 +281,7 @@ export default function AdminConsole() {
               rel="noreferrer"
               className="mt-4 inline-flex items-center gap-2 text-xs text-indigo-200 hover:text-white"
             >
-              Voir la configuration Postiz <ExternalLink className="h-4 w-4" />
+              Voir la configuration orchestrateur social <ExternalLink className="h-4 w-4" />
             </a>
           </div>
         </div>

--- a/src/components/platform/ClientExperience.tsx
+++ b/src/components/platform/ClientExperience.tsx
@@ -48,7 +48,7 @@ const onboardingChecklist = [
   },
   {
     title: "Access réseaux",
-    detail: "Connexion sécurisée Postiz & WordPress",
+    detail: "Connexion sécurisée orchestrateur social & CMS headless",
     icon: LockIcon
   }
 ];

--- a/src/components/platform/SandboxExperience.tsx
+++ b/src/components/platform/SandboxExperience.tsx
@@ -56,7 +56,7 @@ export default function SandboxExperience() {
             ? {
                 ...test,
                 status: "Succès",
-                result: "Simulation Postiz OK — brouillon créé"
+                result: "Simulation orchestrateur social OK — brouillon créé"
               }
             : test
         )
@@ -155,7 +155,7 @@ export default function SandboxExperience() {
           </div>
           <ul className="mt-4 space-y-3 text-xs text-white/60">
             <li>Activer / désactiver la génération de contenus fictifs</li>
-            <li>Simulation publication Postiz uniquement en brouillon</li>
+            <li>Simulation publication orchestrateur social uniquement en brouillon</li>
             <li>Stripe test mode avec webhooks sécurisés</li>
             <li>Option : importer un CSV de clients fictifs</li>
           </ul>
@@ -167,7 +167,7 @@ export default function SandboxExperience() {
           <ul className="mt-4 space-y-3 text-xs text-white/60">
             <li>Exports tests : CSV / PDF / PPT pour démonstrations</li>
             <li>Rapport envoyé à l’admin après chaque batch</li>
-            <li>Capture auto des logs n8n et Postiz</li>
+            <li>Capture auto des logs n8n et orchestrateur social</li>
             <li>
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- replace remaining Postiz and WordPress references with neutral terminology across the demo
- align client, admin and sandbox copy with the updated orchestrateur social / CMS headless wording

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cd760d60e4832c8c38e45190329557