### PR TITLE
Add onboarding auth flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,20 +6,30 @@ import AdminConsole from "./components/platform/AdminConsole";
 import SandboxExperience from "./components/platform/SandboxExperience";
 import RoadmapFeedback from "./components/platform/RoadmapFeedback";
 import NotFound from "./components/platform/NotFound";
+import { AuthProvider } from "./components/auth/AuthProvider";
+import RequireAuth from "./components/auth/RequireAuth";
+import LoginPage from "./components/auth/LoginPage";
+import SignupPage from "./components/auth/SignupPage";
 
 const App = () => (
   <BrowserRouter>
-    <Routes>
-      <Route path="/" element={<NewLandingPage />} />
-      <Route path="/app" element={<PlatformLayout />}>
-        <Route index element={<Navigate to="client" replace />} />
-        <Route path="client" element={<ClientExperience />} />
-        <Route path="admin" element={<AdminConsole />} />
-        <Route path="sandbox" element={<SandboxExperience />} />
-        <Route path="roadmap" element={<RoadmapFeedback />} />
-      </Route>
-      <Route path="*" element={<NotFound />} />
-    </Routes>
+    <AuthProvider>
+      <Routes>
+        <Route path="/" element={<NewLandingPage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<SignupPage />} />
+        <Route element={<RequireAuth />}>
+          <Route path="/app" element={<PlatformLayout />}>
+            <Route index element={<Navigate to="client" replace />} />
+            <Route path="client" element={<ClientExperience />} />
+            <Route path="admin" element={<AdminConsole />} />
+            <Route path="sandbox" element={<SandboxExperience />} />
+            <Route path="roadmap" element={<RoadmapFeedback />} />
+          </Route>
+        </Route>
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </AuthProvider>
   </BrowserRouter>
 );
 

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,197 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from "react";
+
+type AuthUser = {
+  id: string;
+  email: string;
+  name?: string;
+};
+
+type StoredUser = AuthUser & {
+  passwordHash: string;
+};
+
+type SignInPayload = {
+  email: string;
+  password: string;
+};
+
+type SignUpPayload = SignInPayload & {
+  name?: string;
+};
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  loading: boolean;
+  signIn: (payload: SignInPayload) => Promise<void>;
+  signUp: (payload: SignUpPayload) => Promise<void>;
+  signOut: () => Promise<void>;
+};
+
+const CURRENT_USER_KEY = "aeditus_current_user";
+const USERS_KEY = "aeditus_users";
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+const readUsers = (): StoredUser[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+  const raw = window.localStorage.getItem(USERS_KEY);
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as StoredUser[];
+    if (Array.isArray(parsed)) {
+      return parsed.filter((entry): entry is StoredUser => Boolean(entry?.email && entry?.passwordHash));
+    }
+    return [];
+  } catch {
+    return [];
+  }
+};
+
+const persistUsers = (users: StoredUser[]) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(USERS_KEY, JSON.stringify(users));
+};
+
+const readCurrentUser = (): AuthUser | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  const raw = window.localStorage.getItem(CURRENT_USER_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as AuthUser | null;
+    if (parsed && typeof parsed.email === "string" && typeof parsed.id === "string") {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const persistCurrentUser = (user: AuthUser | null) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (!user) {
+    window.localStorage.removeItem(CURRENT_USER_KEY);
+    return;
+  }
+  window.localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(user));
+};
+
+const normalizeEmail = (email: string) => email.trim().toLowerCase();
+
+const hashPassword = async (password: string) => {
+  if (typeof window !== "undefined" && window.crypto?.subtle) {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(password);
+    const digest = await window.crypto.subtle.digest("SHA-256", data);
+    return Array.from(new Uint8Array(digest))
+      .map((value) => value.toString(16).padStart(2, "0"))
+      .join("");
+  }
+  return `plain:${password}`;
+};
+
+const randomId = () => {
+  if (typeof window !== "undefined" && window.crypto?.randomUUID) {
+    return window.crypto.randomUUID();
+  }
+  return `user_${Math.random().toString(36).slice(2)}`;
+};
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setUser(readCurrentUser());
+    setLoading(false);
+  }, []);
+
+  const signIn = useCallback(async ({ email, password }: SignInPayload) => {
+    const safeEmail = normalizeEmail(email);
+    const users = readUsers();
+    const existing = users.find((entry) => entry.email === safeEmail);
+    if (!existing) {
+      throw new Error("Aucun compte trouvé avec cet email. Créez un compte pour commencer.");
+    }
+    const hashed = await hashPassword(password);
+    if (existing.passwordHash !== hashed && existing.passwordHash !== `plain:${password}`) {
+      throw new Error("Identifiants invalides. Vérifiez votre email et votre mot de passe.");
+    }
+    const nextUser: AuthUser = { id: existing.id, email: existing.email, name: existing.name };
+    persistCurrentUser(nextUser);
+    setUser(nextUser);
+    setLoading(false);
+  }, []);
+
+  const signUp = useCallback(async ({ email, password, name }: SignUpPayload) => {
+    const safeEmail = normalizeEmail(email);
+    const users = readUsers();
+    if (users.some((entry) => entry.email === safeEmail)) {
+      throw new Error("Un compte existe déjà avec cet email.");
+    }
+    if (password.length < 8) {
+      throw new Error("Le mot de passe doit contenir au moins 8 caractères.");
+    }
+    const passwordHash = await hashPassword(password);
+    const newUser: StoredUser = {
+      id: randomId(),
+      email: safeEmail,
+      name: name?.trim() || undefined,
+      passwordHash
+    };
+    const nextUsers = [...users, newUser];
+    persistUsers(nextUsers);
+    const nextUser: AuthUser = { id: newUser.id, email: newUser.email, name: newUser.name };
+    persistCurrentUser(nextUser);
+    setUser(nextUser);
+    setLoading(false);
+  }, []);
+
+  const signOut = useCallback(async () => {
+    persistCurrentUser(null);
+    setUser(null);
+    setLoading(false);
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      loading,
+      signIn,
+      signUp,
+      signOut
+    }),
+    [user, loading, signIn, signUp, signOut]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth doit être utilisé à l’intérieur d’un AuthProvider.");
+  }
+  return context;
+};

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -1,0 +1,109 @@
+import { FormEvent, useState } from "react";
+import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
+import { useAuth } from "./AuthProvider";
+
+type LocationState = {
+  from?: string;
+};
+
+const LoginPage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = (location.state as LocationState | null) ?? {};
+  const fromPath = typeof state.from === "string" && state.from.length > 0 ? state.from : "/app/client";
+  const { signIn, user, loading } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!loading && user) {
+    return <Navigate to="/app/client" replace />;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      await signIn({ email, password });
+      navigate(fromPath, { replace: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Impossible de vous connecter.";
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen bg-slate-950">
+      <div className="mx-auto flex w-full max-w-md flex-col justify-center px-4 py-12 sm:px-6 lg:px-8">
+        <Link to="/" className="mb-8 inline-flex items-center text-sm text-white/70 transition hover:text-white">
+          ← Retour à la landing
+        </Link>
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-xl backdrop-blur">
+          <h1 className="font-heading text-2xl text-white">Connexion</h1>
+          <p className="mt-2 text-sm text-white/60">Identifiez-vous pour accéder à votre espace Æditus.</p>
+          {state.from && (
+            <p className="mt-4 rounded-xl border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-xs text-amber-100">
+              Veuillez vous connecter pour accéder à <span className="font-semibold">{state.from}</span>.
+            </p>
+          )}
+          {error && (
+            <p className="mt-4 rounded-xl border border-rose-500/50 bg-rose-500/10 px-4 py-2 text-xs text-rose-100">{error}</p>
+          )}
+          <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <label htmlFor="email" className="text-sm font-medium text-white">
+                Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-[#0B1110] px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-medium text-white">
+                Mot de passe
+              </label>
+              <input
+                id="password"
+                type="password"
+                autoComplete="current-password"
+                required
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-[#0B1110] px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex w-full items-center justify-center rounded-xl bg-indigo-500 px-4 py-3 text-sm font-semibold text-[#0B1110] transition hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {submitting ? "Connexion en cours..." : "Se connecter"}
+            </button>
+          </form>
+          <p className="mt-6 text-center text-xs text-white/60">
+            Pas de compte ?{" "}
+            <Link
+              to="/register"
+              state={{ from: fromPath }}
+              className="font-semibold text-indigo-200 transition hover:text-white"
+            >
+              Créez votre espace Æditus
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,23 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useAuth } from "./AuthProvider";
+
+const RequireAuth = () => {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-white">
+        Chargement...
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: `${location.pathname}${location.search}` }} />;
+  }
+
+  return <Outlet />;
+};
+
+export default RequireAuth;

--- a/src/components/auth/SignupPage.tsx
+++ b/src/components/auth/SignupPage.tsx
@@ -1,0 +1,139 @@
+import { FormEvent, useState } from "react";
+import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
+import { useAuth } from "./AuthProvider";
+
+type LocationState = {
+  from?: string;
+};
+
+const SignupPage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = (location.state as LocationState | null) ?? {};
+  const fromPath = typeof state.from === "string" && state.from.length > 0 ? state.from : "/app/client";
+  const { signUp, user, loading } = useAuth();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!loading && user) {
+    return <Navigate to="/app/client" replace />;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    if (password !== confirmPassword) {
+      setError("Les mots de passe ne correspondent pas.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await signUp({ email, password, name });
+      navigate(fromPath, { replace: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Impossible de créer votre compte.";
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen bg-slate-950">
+      <div className="mx-auto flex w-full max-w-md flex-col justify-center px-4 py-12 sm:px-6 lg:px-8">
+        <Link to="/" className="mb-8 inline-flex items-center text-sm text-white/70 transition hover:text-white">
+          ← Retour à la landing
+        </Link>
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-xl backdrop-blur">
+          <h1 className="font-heading text-2xl text-white">Créer votre compte</h1>
+          <p className="mt-2 text-sm text-white/60">
+            Enregistrez-vous pour accéder à la plateforme et tester Æditus.
+          </p>
+          {error && (
+            <p className="mt-4 rounded-xl border border-rose-500/50 bg-rose-500/10 px-4 py-2 text-xs text-rose-100">{error}</p>
+          )}
+          <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <label htmlFor="name" className="text-sm font-medium text-white">
+                Nom / Société (optionnel)
+              </label>
+              <input
+                id="name"
+                type="text"
+                autoComplete="organization"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-[#0B1110] px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="email" className="text-sm font-medium text-white">
+                Email professionnel
+              </label>
+              <input
+                id="email"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-[#0B1110] px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-medium text-white">
+                Mot de passe
+              </label>
+              <input
+                id="password"
+                type="password"
+                autoComplete="new-password"
+                required
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-[#0B1110] px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="confirm-password" className="text-sm font-medium text-white">
+                Confirmez le mot de passe
+              </label>
+              <input
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                required
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-[#0B1110] px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex w-full items-center justify-center rounded-xl bg-cyan-500 px-4 py-3 text-sm font-semibold text-[#0B1110] transition hover:bg-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-400/60 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {submitting ? "Création en cours..." : "Créer mon compte"}
+            </button>
+          </form>
+          <p className="mt-6 text-center text-xs text-white/60">
+            Déjà inscrit ?{" "}
+            <Link
+              to="/login"
+              state={{ from: fromPath }}
+              className="font-semibold text-indigo-200 transition hover:text-white"
+            >
+              Retour à la connexion
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignupPage;

--- a/src/components/landing/NewLandingPage.tsx
+++ b/src/components/landing/NewLandingPage.tsx
@@ -373,26 +373,54 @@ export default function AeditusLanding() {
             <span className="font-heading text-white/90 group-hover:text-white">Æditus</span>
           </a>
           <div className="hidden items-center gap-6 md:flex">
-          <a href="#about" className="text-sm text-white/70 hover:text-white">Fonctionnalités</a>
-          <a href="#semaine-type" className="text-sm text-white/70 hover:text-white">Comment ça marche</a>
-          <a href="#offres" className="text-sm text-white/70 hover:text-white">Offres</a>
-          <a href="#faq" className="text-sm text-white/70 hover:text-white">FAQ</a>
-          <Link to="/app/client" className="text-sm text-white/70 transition hover:text-white">
-            Plateforme
-          </Link>
-        </div>
-        <div className="flex items-center gap-3">
-          <Link
-            to="/app/client"
-            className="hidden rounded-xl border border-white/10 px-4 py-2 text-sm text-white/80 transition hover:bg-white/5 md:inline-flex"
-          >
-            Voir la plateforme
-          </Link>
-          <a href="#offres" className="hidden rounded-xl border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/5 md:inline-flex">Voir les offres</a>
-          <a href="#offres" className="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-[#0B1110] hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60">
-            Démarrer l’essai 7 jours <ChevronRight className="h-4 w-4" />
-          </a>
-        </div>
+            <a href="#about" className="text-sm text-white/70 hover:text-white">
+              Fonctionnalités
+            </a>
+            <a href="#semaine-type" className="text-sm text-white/70 hover:text-white">
+              Comment ça marche
+            </a>
+            <a href="#offres" className="text-sm text-white/70 hover:text-white">
+              Offres
+            </a>
+            <a href="#faq" className="text-sm text-white/70 hover:text-white">
+              FAQ
+            </a>
+            <Link to="/app/client" className="text-sm text-white/70 transition hover:text-white">
+              Plateforme
+            </Link>
+            <Link to="/login" className="text-sm text-white/70 transition hover:text-white">
+              Connexion
+            </Link>
+            <Link to="/register" className="text-sm text-white/70 transition hover:text-white">
+              Inscription
+            </Link>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link
+              to="/login"
+              className="inline-flex items-center gap-2 rounded-xl border border-white/10 px-4 py-2 text-sm text-white/80 transition hover:bg-white/5"
+            >
+              Connexion
+            </Link>
+            <Link
+              to="/app/client"
+              className="hidden rounded-xl border border-white/10 px-4 py-2 text-sm text-white/80 transition hover:bg-white/5 md:inline-flex"
+            >
+              Voir la plateforme
+            </Link>
+            <a
+              href="#offres"
+              className="hidden rounded-xl border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/5 md:inline-flex"
+            >
+              Voir les offres
+            </a>
+            <a
+              href="#offres"
+              className="inline-flex items-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-[#0B1110] hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+            >
+              Démarrer l’essai 7 jours <ChevronRight className="h-4 w-4" />
+            </a>
+          </div>
         </nav>
       </header>
 

--- a/src/components/platform/PlatformLayout.tsx
+++ b/src/components/platform/PlatformLayout.tsx
@@ -1,12 +1,14 @@
-import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
+import { Link, NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import {
   ArrowLeft,
   Bot,
   ClipboardCheck,
   LayoutDashboard,
+  LogOut,
   Rocket,
   ShieldCheck
 } from "lucide-react";
+import { useAuth } from "../auth/AuthProvider";
 
 const navItems = [
   {
@@ -42,6 +44,13 @@ const navItems = [
 export default function PlatformLayout() {
   const location = useLocation();
   const active = navItems.find((item) => location.pathname.includes(item.to));
+  const navigate = useNavigate();
+  const { user, signOut } = useAuth();
+
+  const handleSignOut = async () => {
+    await signOut();
+    navigate("/login", { replace: true });
+  };
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-50">
@@ -61,10 +70,22 @@ export default function PlatformLayout() {
               </h1>
             </div>
           </div>
-          <div className="hidden items-center gap-3 md:flex">
-            <span className="inline-flex items-center gap-2 rounded-xl border border-indigo-400/30 bg-indigo-400/10 px-3 py-1 text-xs text-indigo-200">
+          <div className="flex items-center gap-3">
+            <span className="hidden items-center gap-2 rounded-xl border border-indigo-400/30 bg-indigo-400/10 px-3 py-1 text-xs text-indigo-200 md:inline-flex">
               <ClipboardCheck className="h-4 w-4" /> Version démo connectée
             </span>
+            {user && (
+              <span className="max-w-[160px] truncate rounded-xl border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/80">
+                {user.name ?? user.email}
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={handleSignOut}
+              className="inline-flex items-center gap-2 rounded-xl border border-white/10 px-3 py-1 text-xs text-white/80 transition hover:bg-white/10"
+            >
+              <LogOut className="h-3 w-3" /> Déconnexion
+            </button>
           </div>
         </div>
         <nav className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 pb-4 md:px-6">


### PR DESCRIPTION
## Summary
- implement a client-side AuthProvider backed by localStorage with hashed passwords and expose sign-in/up/out helpers and RequireAuth guard
- add dedicated login and signup pages, update the platform header with the signed-in user badge and sign-out action
- expose authentication entry points from the landing page and protect the `/app` routes behind authentication

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cd793f20dc832cba29cef38d1b13b1