### PR TITLE
Fix Vercel configuration fallbacks and proxy forwarding

### DIFF
--- a/api/n8n-proxy.ts
+++ b/api/n8n-proxy.ts
@@ -1,7 +1,8 @@
 export async function POST(request: Request) {
   const {
     path = '/webhook/aeditus/health',
-    token = process.env.N8N_TOKEN
+    token = process.env.N8N_TOKEN,
+    payload
   } = await request.json()
 
   if (!process.env.N8N_BASE_URL) {
@@ -12,8 +13,15 @@ export async function POST(request: Request) {
   }
 
   const url = `${process.env.N8N_BASE_URL}${path}`
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
   const response = await fetch(url, {
-    headers: token ? { Authorization: `Bearer ${token}` } : undefined
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload ?? {})
   })
   const text = await response.text()
   return new Response(text, { status: response.status })

--- a/api/postiz-proxy.ts
+++ b/api/postiz-proxy.ts
@@ -1,7 +1,8 @@
 export async function POST(request: Request) {
   const {
     endpoint = '/api/health',
-    apiKey = process.env.POSTIZ_API_KEY
+    apiKey = process.env.POSTIZ_API_KEY,
+    payload
   } = await request.json()
 
   if (!process.env.POSTIZ_BASE_URL) {
@@ -12,8 +13,15 @@ export async function POST(request: Request) {
   }
 
   const url = `${process.env.POSTIZ_BASE_URL}${endpoint}`
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`
+  }
+
   const response = await fetch(url, {
-    headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload ?? {})
   })
   const text = await response.text()
   return new Response(text, { status: response.status })

--- a/api/stripe-create-checkout-session.ts
+++ b/api/stripe-create-checkout-session.ts
@@ -15,12 +15,13 @@ function getStripeSecretKey(): string {
   return secret
 }
 
-function getSiteUrl(): string {
+function getSiteUrl(request: Request): string {
   const siteUrl = process.env.SITE_URL
-  if (!siteUrl) {
-    throw new Error('Missing SITE_URL environment variable')
+  if (siteUrl) {
+    return siteUrl
   }
-  return siteUrl
+
+  return new URL(request.url).origin
 }
 
 export async function POST(request: Request) {
@@ -41,7 +42,7 @@ export async function POST(request: Request) {
     params.append('line_items[0][quantity]', '1')
     params.append('allow_promotion_codes', 'true')
 
-    const siteUrl = getSiteUrl()
+    const siteUrl = getSiteUrl(request)
     params.append('success_url', `${siteUrl}${successPath}?session_id={CHECKOUT_SESSION_ID}`)
     params.append('cancel_url', `${siteUrl}${cancelPath}`)
 

--- a/api/stripe-portal-link.ts
+++ b/api/stripe-portal-link.ts
@@ -15,12 +15,13 @@ function getStripeSecretKey(): string {
   return secret
 }
 
-function getSiteUrl(): string {
+function getSiteUrl(request: Request): string {
   const siteUrl = process.env.SITE_URL
-  if (!siteUrl) {
-    throw new Error('Missing SITE_URL environment variable')
+  if (siteUrl) {
+    return siteUrl
   }
-  return siteUrl
+
+  return new URL(request.url).origin
 }
 
 export async function POST(request: Request) {
@@ -36,7 +37,7 @@ export async function POST(request: Request) {
 
     const params = new URLSearchParams()
     params.append('customer', customerId)
-    params.append('return_url', `${getSiteUrl()}${returnPath}`)
+    params.append('return_url', `${getSiteUrl(request)}${returnPath}`)
 
     const response = await fetch(`${STRIPE_API_BASE_URL}/billing_portal/sessions`, {
       method: 'POST',

--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,8 @@
       "memory": 256,
       "maxDuration": 10
     }
-  }
+  },
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
 }


### PR DESCRIPTION
## Summary
- add a SPA rewrite rule to the Vercel configuration
- allow Stripe API handlers to fall back to the request origin when SITE_URL is missing
- forward JSON payloads and authorization headers through the n8n and Postiz proxies

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cd958da68c832c9afc414c3dff9e7e