### PR TITLE
fix(vercel): remove invalid runtime key

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vite_react_shadcn_ts",
   "private": true,
   "version": "0.0.0",
+  "engines": { "node": "20.x" },
   "packageManager": "pnpm@10.5.2",
   "type": "module",
   "scripts": {

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,7 @@
     }
   },
   "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/(.*)", "destination": "/" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,15 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
   "buildCommand": "pnpm build",
   "outputDirectory": "dist",
   "functions": {
     "api/**/*.ts": {
-      "runtime": "nodejs20.x",
       "memory": 256,
       "maxDuration": 10
     }
-  }
+  },
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
 }


### PR DESCRIPTION
## Summary
- remove the custom runtime configuration from vercel.json and rely on Vercel defaults
- document the desired Node.js version with an engines field in package.json

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd96d0d3c0832c820b5b71a0a8c989