### PR TITLE
fix(router): export useNavigate hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vite_react_shadcn_ts",
   "private": true,
   "version": "0.0.0",
+  "engines": { "node": "20.x" },
   "packageManager": "pnpm@10.5.2",
   "type": "module",
   "scripts": {

--- a/src/lib/router.tsx
+++ b/src/lib/router.tsx
@@ -58,6 +58,8 @@ const useRouteContext = () => useContext(RouteContext);
 
 export const useLocation = () => useRouter().location;
 
+export const useNavigate = () => useRouter().navigate;
+
 export const Outlet = () => {
   const outlet = useContext(OutletContext);
   return <>{outlet}</>;

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,16 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
   "buildCommand": "pnpm build",
   "outputDirectory": "dist",
   "functions": {
     "api/**/*.ts": {
-      "runtime": "nodejs20.x",
       "memory": 256,
       "maxDuration": 10
     }
-  }
+  },
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" },
+    { "source": "/(.*)", "destination": "/" }
+  ]
 }


### PR DESCRIPTION
## Summary
- restore the explicit /api passthrough rewrite ahead of the SPA fallback in vercel.json
- export the custom router's useNavigate hook so components can navigate during builds

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cd96d0d3c0832c820b5b71a0a8c989