### PR TITLE
feat: build authenticated dashboards and enhanced landing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,19 @@ import LoginPage from "./components/auth/LoginPage";
 import SignupPage from "./components/auth/SignupPage";
 import AppLayout from "./components/app/AppLayout";
 import HomePage from "./components/app/HomePage";
+import PlanPage from "./components/app/PlanPage";
+import CalendarPage from "./components/app/CalendarPage";
+import ContentsListPage from "./components/app/ContentsListPage";
+import ContentDetailPage from "./components/app/ContentDetailPage";
+import ContentCreatePage from "./components/app/ContentCreatePage";
+import ContentImportPage from "./components/app/ContentImportPage";
+import TasksPage from "./components/app/TasksPage";
+import TaskCreatePage from "./components/app/TaskCreatePage";
+import AnalyticsPage from "./components/app/AnalyticsPage";
+import FynkPage from "./components/app/FynkPage";
+import BillingPage from "./components/app/BillingPage";
+import SettingsPage from "./components/app/SettingsPage";
+import HelpPage from "./components/app/HelpPage";
 
 const App = () => (
   <BrowserRouter>
@@ -24,15 +37,19 @@ const App = () => (
           {/* New app structure */}
           <Route path="/app" element={<AppLayout />}>
             <Route index element={<HomePage />} />
-            <Route path="plan" element={<div>Plan éditorial</div>} />
-            <Route path="calendar" element={<div>Calendrier</div>} />
-            <Route path="contents" element={<div>Contenus</div>} />
-            <Route path="tasks" element={<div>Tâches</div>} />
-            <Route path="analytics" element={<div>Analytics</div>} />
-            <Route path="fynk" element={<div>Fynk</div>} />
-            <Route path="billing" element={<div>Facturation</div>} />
-            <Route path="settings" element={<div>Paramètres</div>} />
-            <Route path="help" element={<div>Aide</div>} />
+            <Route path="plan" element={<PlanPage />} />
+            <Route path="calendar" element={<CalendarPage />} />
+            <Route path="contents" element={<ContentsListPage />} />
+            <Route path="contents/new" element={<ContentCreatePage />} />
+            <Route path="contents/import" element={<ContentImportPage />} />
+            <Route path="contents/:id" element={<ContentDetailPage />} />
+            <Route path="tasks" element={<TasksPage />} />
+            <Route path="tasks/new" element={<TaskCreatePage />} />
+            <Route path="analytics" element={<AnalyticsPage />} />
+            <Route path="fynk" element={<FynkPage />} />
+            <Route path="billing" element={<BillingPage />} />
+            <Route path="settings" element={<SettingsPage />} />
+            <Route path="help" element={<HelpPage />} />
           </Route>
           {/* Legacy platform routes */}
           <Route path="/platform" element={<PlatformLayout />}>

--- a/src/components/app/AnalyticsPage.tsx
+++ b/src/components/app/AnalyticsPage.tsx
@@ -1,0 +1,188 @@
+import React, { useMemo, useState } from "react";
+import { analyticsSnapshot, mockContents } from "@/lib/mockAppData";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+const formatPercent = (value: number) => `${Math.round(value * 100)}%`;
+
+export default function AnalyticsPage() {
+  const [channelFilter, setChannelFilter] = useState<string>("");
+  const [personFilter, setPersonFilter] = useState<string>("");
+  const [period, setPeriod] = useState<string>("30");
+
+  const filteredContents = useMemo(() => {
+    return mockContents.filter((content) => {
+      if (channelFilter && content.channel !== channelFilter) return false;
+      if (personFilter && content.assignee !== personFilter) return false;
+      return true;
+    });
+  }, [channelFilter, personFilter]);
+
+  const created = filteredContents.length;
+  const published = filteredContents.filter((content) => content.status === "published").length;
+  const scheduled = filteredContents.filter((content) => content.status === "scheduled").length;
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Analytics</h1>
+          <p className="text-sm text-muted-foreground">
+            Vélocité, respect des délais et charge par canal. Les filtres s'appliquent aux cartes et graphiques.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-sm">
+          <select
+            className="rounded-md border bg-background px-3 py-2"
+            value={period}
+            onChange={(event) => setPeriod(event.target.value)}
+          >
+            <option value="7">7 jours</option>
+            <option value="30">30 jours</option>
+            <option value="90">90 jours</option>
+          </select>
+          <select
+            className="rounded-md border bg-background px-3 py-2"
+            value={channelFilter}
+            onChange={(event) => setChannelFilter(event.target.value)}
+          >
+            <option value="">Tous les canaux</option>
+            {Array.from(new Set(mockContents.map((item) => item.channel))).map((channel) => (
+              <option key={channel} value={channel}>
+                {channel}
+              </option>
+            ))}
+          </select>
+          <select
+            className="rounded-md border bg-background px-3 py-2"
+            value={personFilter}
+            onChange={(event) => setPersonFilter(event.target.value)}
+          >
+            <option value="">Toute l'équipe</option>
+            {Array.from(new Set(mockContents.map((item) => item.assignee))).map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Contenus créés ({period}j)</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{created}</p>
+            <p className="text-xs text-muted-foreground">dont {scheduled} planifiés</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Contenus publiés</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{published}</p>
+            <p className="text-xs text-muted-foreground">Vs objectif {analyticsSnapshot.published}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Respect des délais</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{formatPercent(analyticsSnapshot.onTimeRate)}</p>
+            <p className="text-xs text-muted-foreground">Tendance +4 % vs période précédente</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Temps moyen de cycle</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">3,8 j</p>
+            <p className="text-xs text-muted-foreground">Idée → Publication</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Vélocité par personne</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            {analyticsSnapshot.velocity.map((item) => {
+              const max = Math.max(...analyticsSnapshot.velocity.map((entry) => entry.value));
+              return (
+                <div key={item.user} className="space-y-1">
+                  <div className="flex items-center justify-between">
+                    <span>{item.user}</span>
+                    <Badge variant="outline">{item.value}/semaine</Badge>
+                  </div>
+                  <div className="h-2 w-full rounded-full bg-muted">
+                    <div
+                      className="h-2 rounded-full bg-primary"
+                      style={{ width: `${Math.max(12, (item.value / max) * 100)}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Répartition statuts</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            {[
+              { label: "Idées", count: filteredContents.filter((item) => item.status === "idea").length },
+              { label: "Brouillons", count: filteredContents.filter((item) => item.status === "draft").length },
+              { label: "Révision", count: filteredContents.filter((item) => item.status === "review").length },
+              { label: "Prêts", count: filteredContents.filter((item) => item.status === "ready").length },
+            ].map((entry) => (
+              <div key={entry.label} className="flex items-center justify-between">
+                <span>{entry.label}</span>
+                <span className="font-medium">{entry.count}</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Charge par canal</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {analyticsSnapshot.loadByChannel.map((item) => {
+            const max = Math.max(...analyticsSnapshot.loadByChannel.map((entry) => entry.planned));
+            return (
+              <div key={item.channel} className="space-y-2">
+                <div className="flex items-center justify-between text-sm font-medium">
+                  <span>{item.channel}</span>
+                  <span>
+                    {item.planned} planifiés • {item.published} publiés
+                  </span>
+                </div>
+                <div className="h-2 w-full rounded-full bg-muted">
+                  <div
+                    className="h-2 rounded-full bg-secondary"
+                    style={{ width: `${(item.planned / max) * 100}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+          <Button variant="outline" size="sm">
+            Exporter les données détaillées
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app/AppLayout.tsx
+++ b/src/components/app/AppLayout.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { Outlet, Link, useLocation } from "react-router-dom";
+/* eslint-disable react-refresh/only-export-components */
+import React, { useMemo } from "react";
+import { Outlet, Link, useLocation, useOutletContext } from "react-router-dom";
 import {
   Home,
   Calendar,
@@ -15,7 +16,10 @@ import {
   Bell,
   User,
   LogOut,
-  Building2
+  Building2,
+  Info,
+  PencilRuler,
+  ArrowRightLeft,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -27,49 +31,100 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { mockOrganization } from "@/lib/mockAppData";
 
-const sidebarItems = [
+type AppUser = {
+  firstName: string;
+  email: string;
+  role: "owner" | "admin" | "editor" | "viewer";
+  avatar?: string | null;
+  hasFynkAddOn: boolean;
+};
+
+export type AppLayoutContext = {
+  user: AppUser;
+  organization: typeof mockOrganization;
+};
+
+const baseNavigation = [
   { href: "/app", icon: Home, label: "Accueil" },
   { href: "/app/plan", icon: FileText, label: "Plan éditorial" },
   { href: "/app/calendar", icon: Calendar, label: "Calendrier" },
   { href: "/app/contents", icon: FileText, label: "Contenus" },
   { href: "/app/tasks", icon: CheckSquare, label: "Tâches" },
   { href: "/app/analytics", icon: BarChart3, label: "Analytics" },
-  { href: "/app/fynk", icon: Zap, label: "Fynk" },
-  { href: "/app/billing", icon: CreditCard, label: "Facturation" },
   { href: "/app/settings", icon: Settings, label: "Paramètres" },
   { href: "/app/help", icon: HelpCircle, label: "Aide" },
 ];
 
+const ownerNavigation = [
+  { href: "/app/billing", icon: CreditCard, label: "Facturation" },
+];
+
+export const useAppLayoutContext = () => useOutletContext<AppLayoutContext>();
+
 export default function AppLayout() {
   const location = useLocation();
-  const user = { firstName: "Nathalie", avatar: null }; // TODO: Get from auth
+  const user: AppUser = {
+    firstName: "Nathalie",
+    email: "nathalie@aeditus.com",
+    role: "owner",
+    avatar: null,
+    hasFynkAddOn: true,
+  };
+
+  const navigation = useMemo(() => {
+    const items = [...baseNavigation];
+
+    if (user.hasFynkAddOn) {
+      items.splice(6, 0, { href: "/app/fynk", icon: Zap, label: "Fynk" });
+    }
+
+    if (user.role === "owner" || user.role === "admin") {
+      items.splice(items.length - 2, 0, ...ownerNavigation);
+    }
+
+    return items;
+  }, [user.hasFynkAddOn, user.role]);
+
+  const contextValue: AppLayoutContext = {
+    user,
+    organization: mockOrganization,
+  };
 
   return (
     <div className="flex min-h-screen w-full bg-background">
       {/* Sidebar */}
       <aside className="w-64 border-r bg-card">
-        <div className="flex h-16 items-center border-b px-6">
-          <Link to="/app" className="flex items-center gap-2">
+        <div className="flex h-16 items-center justify-between border-b px-6">
+          <Link to="/app" className="flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md px-1 py-1">
             <div className="grid h-8 w-8 place-items-center rounded-xl bg-gradient-to-br from-primary to-secondary text-primary-foreground font-bold">
               Æ
             </div>
             <span className="font-heading text-lg font-semibold">Æditus</span>
           </Link>
+          <Link
+            to="/"
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md px-1 py-1"
+          >
+            <Info className="h-3.5 w-3.5" />
+            Landing
+          </Link>
         </div>
-        
+
         <nav className="p-4 space-y-2">
-          {sidebarItems.map(({ href, icon: Icon, label }) => {
-            const isActive = location.pathname === href || 
-              (href !== "/app" && location.pathname.startsWith(href));
-            
+          {navigation.map(({ href, icon: Icon, label }) => {
+            const isActive =
+              location.pathname === href || (href !== "/app" && location.pathname.startsWith(href));
+
             return (
               <Link
                 key={href}
                 to={href}
-                className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
-                  isActive 
-                    ? "bg-primary text-primary-foreground" 
+                aria-current={isActive ? "page" : undefined}
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                  isActive
+                    ? "bg-primary text-primary-foreground"
                     : "text-muted-foreground hover:bg-muted hover:text-foreground"
                 }`}
               >
@@ -87,7 +142,7 @@ export default function AppLayout() {
         <header className="sticky top-0 z-10 border-b bg-background/80 backdrop-blur">
           <div className="flex h-16 items-center justify-between px-6">
             <div className="flex items-center gap-4">
-              <div className="relative w-80">
+              <div className="relative w-80 max-w-full">
                 <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                 <Input
                   placeholder="Rechercher... (Ctrl/Cmd+K)"
@@ -105,14 +160,29 @@ export default function AppLayout() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem>
-                    <Link to="/app/contents/new" className="flex items-center">
-                      Nouveau contenu
+                  <DropdownMenuItem asChild>
+                    <Link to="/app/contents/new" className="flex items-center gap-2">
+                      <PenLine className="h-4 w-4" />
+                      Nouveau sujet
                     </Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem>
-                    <Link to="/app/tasks/new" className="flex items-center">
+                  <DropdownMenuItem asChild>
+                    <Link to="/app/contents/new?type=article" className="flex items-center gap-2">
+                      <FileText className="h-4 w-4" />
+                      Nouvel article
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <Link to="/app/tasks/new" className="flex items-center gap-2">
+                      <CheckSquare className="h-4 w-4" />
                       Nouvelle tâche
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
+                    <Link to="/app/contents/import" className="flex items-center gap-2">
+                      <ArrowRightLeft className="h-4 w-4" />
+                      Import CSV
                     </Link>
                   </DropdownMenuItem>
                 </DropdownMenuContent>
@@ -127,7 +197,7 @@ export default function AppLayout() {
                 <DropdownMenuTrigger asChild>
                   <Button variant="ghost" className="relative h-8 w-8 rounded-full">
                     <Avatar className="h-8 w-8">
-                      <AvatarImage src={user.avatar} alt={user.firstName} />
+                      <AvatarImage src={user.avatar ?? undefined} alt={user.firstName} />
                       <AvatarFallback>{user.firstName?.[0]}</AvatarFallback>
                     </Avatar>
                   </Button>
@@ -163,7 +233,7 @@ export default function AppLayout() {
 
         {/* Page content */}
         <div className="p-6">
-          <Outlet />
+          <Outlet context={contextValue} />
         </div>
       </main>
     </div>

--- a/src/components/app/BillingPage.tsx
+++ b/src/components/app/BillingPage.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { mockOrganization, mockInvoices } from "@/lib/mockAppData";
+import { Badge } from "@/components/ui/badge";
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("fr-FR", { style: "currency", currency: "EUR" }).format(value);
+
+export default function BillingPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Facturation</h1>
+        <p className="text-sm text-muted-foreground">
+          Consultez vos plans, factures et accédez au portail Stripe pour modifier votre abonnement.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Plan actuel</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="text-lg font-semibold">Offre {mockOrganization.currentPlan}</p>
+              <p className="text-muted-foreground">Facturation mensuelle. Prochaine échéance le {mockOrganization.nextInvoiceDate}.</p>
+            </div>
+            <Badge variant="secondary">Actif</Badge>
+          </div>
+          <div className="rounded-md bg-muted p-4">
+            <p className="text-sm">
+              Quotas hebdo :
+            </p>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
+              {Object.entries(mockOrganization.quotas.weekly).map(([channel, value]) => (
+                <li key={channel}>
+                  {channel} : {value}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button>Mettre à niveau</Button>
+            <Button variant="outline" asChild>
+              <a href="https://billing.stripe.com" target="_blank" rel="noreferrer">
+                Ouvrir le portail Stripe
+              </a>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Historique des factures</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          {mockInvoices.map((invoice) => (
+            <div key={invoice.id} className="flex flex-wrap items-center justify-between rounded border px-3 py-2">
+              <div>
+                <p className="font-medium">{invoice.date}</p>
+                <p className="text-xs text-muted-foreground">Référence {invoice.id}</p>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="font-medium">{formatCurrency(invoice.amount)}</span>
+                <Button variant="outline" size="sm" asChild>
+                  <a href={invoice.url} target="_blank" rel="noreferrer">
+                    Télécharger
+                  </a>
+                </Button>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app/CalendarPage.tsx
+++ b/src/components/app/CalendarPage.tsx
@@ -1,0 +1,392 @@
+import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { mockContents } from "@/lib/mockAppData";
+import { useAppLayoutContext } from "./AppLayout";
+import { Calendar as CalendarIcon, Download, ChevronLeft, ChevronRight, List } from "lucide-react";
+
+type CalendarView = "month" | "week" | "list";
+
+type CalendarEvent = {
+  id: string;
+  title: string;
+  plannedAt: string;
+  status: string;
+  channel: string;
+  contentId: string;
+};
+
+const toDateKey = (value: string | Date) => {
+  const date = typeof value === "string" ? new Date(value) : value;
+  const year = date.getUTCFullYear();
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getUTCDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const generateICS = (events: CalendarEvent[]) => {
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Æditus//Calendar//FR",
+  ];
+
+  events.forEach((event) => {
+    const start = new Date(event.plannedAt);
+    const dtStart = `${start.getUTCFullYear()}${`${start.getUTCMonth() + 1}`.padStart(2, "0")}${`${start.getUTCDate()}`.padStart(2, "0")}T${`${start.getUTCHours()}`.padStart(2, "0")}${`${start.getUTCMinutes()}`.padStart(2, "0")}00Z`;
+    const dtEndDate = new Date(start);
+    dtEndDate.setUTCHours(dtEndDate.getUTCHours() + 1);
+    const dtEnd = `${dtEndDate.getUTCFullYear()}${`${dtEndDate.getUTCMonth() + 1}`.padStart(2, "0")}${`${dtEndDate.getUTCDate()}`.padStart(2, "0")}T${`${dtEndDate.getUTCHours()}`.padStart(2, "0")}${`${dtEndDate.getUTCMinutes()}`.padStart(2, "0")}00Z`;
+
+    lines.push("BEGIN:VEVENT");
+    lines.push(`UID:${event.id}@aeditus`);
+    lines.push(`DTSTAMP:${dtStart}`);
+    lines.push(`DTSTART:${dtStart}`);
+    lines.push(`DTEND:${dtEnd}`);
+    lines.push(`SUMMARY:${event.title}`);
+    lines.push(`DESCRIPTION:Statut ${event.status} • Canal ${event.channel}`);
+    lines.push(`URL:https://app.aeditus.com/app/contents/${event.contentId}`);
+    lines.push("END:VEVENT");
+  });
+
+  lines.push("END:VCALENDAR");
+  return lines.join("\r\n");
+};
+
+const heatLevel = (count: number, weeklyTarget: number) => {
+  if (count === 0) return "bg-muted";
+  if (count >= weeklyTarget) return "bg-destructive/40";
+  if (count >= weeklyTarget * 0.75) return "bg-warning/40";
+  return "bg-primary/20";
+};
+
+const initialEvents: CalendarEvent[] = mockContents
+  .filter((content) => content.plannedAt)
+  .map((content) => ({
+    id: content.id,
+    title: content.title,
+    plannedAt: content.plannedAt!,
+    status: content.status,
+    channel: content.channel,
+    contentId: content.id,
+  }));
+
+export default function CalendarPage() {
+  const { organization } = useAppLayoutContext();
+  const [events, setEvents] = useState<CalendarEvent[]>(initialEvents);
+  const [view, setView] = useState<CalendarView>("month");
+  const [currentDate, setCurrentDate] = useState(() => new Date("2025-01-23T08:00:00.000Z"));
+  const [modal, setModal] = useState<{ open: boolean; date: string; title: string; channel: string }>(
+    { open: false, date: "", title: "", channel: "Blog" }
+  );
+
+  const monthlyEvents = useMemo(() => {
+    const grouped = new Map<string, CalendarEvent[]>();
+    events.forEach((event) => {
+      const key = toDateKey(event.plannedAt);
+      if (!grouped.has(key)) {
+        grouped.set(key, []);
+      }
+      grouped.get(key)!.push(event);
+    });
+    return grouped;
+  }, [events]);
+
+  const matrix = useMemo(() => {
+    const firstDay = new Date(Date.UTC(currentDate.getUTCFullYear(), currentDate.getUTCMonth(), 1));
+    const startOffset = (firstDay.getUTCDay() + 6) % 7; // Monday start
+    const start = new Date(firstDay);
+    start.setUTCDate(start.getUTCDate() - startOffset);
+
+    return Array.from({ length: 42 }, (_, index) => {
+      const day = new Date(start);
+      day.setUTCDate(start.getUTCDate() + index);
+      const key = toDateKey(day);
+      return {
+        date: day,
+        key,
+        events: monthlyEvents.get(key) ?? [],
+      };
+    });
+  }, [currentDate, monthlyEvents]);
+
+  const currentMonthLabel = useMemo(
+    () =>
+      new Intl.DateTimeFormat("fr-FR", { month: "long", year: "numeric" }).format(
+        new Date(currentDate.getUTCFullYear(), currentDate.getUTCMonth())
+      ),
+    [currentDate]
+  );
+
+  const weekEvents = useMemo(() => {
+    const start = new Date(currentDate);
+    const day = (start.getUTCDay() + 6) % 7;
+    start.setUTCDate(start.getUTCDate() - day);
+    const end = new Date(start);
+    end.setUTCDate(start.getUTCDate() + 7);
+    return events.filter((event) => {
+      const planned = new Date(event.plannedAt);
+      return planned >= start && planned < end;
+    });
+  }, [events, currentDate]);
+
+  const upcomingList = useMemo(
+    () => [...events].sort((a, b) => a.plannedAt.localeCompare(b.plannedAt)),
+    [events]
+  );
+
+  const weeklyQuota = Object.values(organization.quotas.weekly).reduce((sum, value) => sum + value, 0);
+
+  const changeMonth = (offset: number) => {
+    setCurrentDate((prev) => {
+      const next = new Date(prev);
+      next.setUTCMonth(prev.getUTCMonth() + offset, 1);
+      return next;
+    });
+  };
+
+  const onExport = () => {
+    const blob = new Blob([generateICS(events)], { type: "text/calendar;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "aeditus-calendar.ics";
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const onReplan = (id: string) => {
+    setEvents((prev) =>
+      prev.map((event) =>
+        event.id === id
+          ? {
+              ...event,
+              plannedAt: new Date(new Date(event.plannedAt).getTime() + 24 * 60 * 60 * 1000).toISOString(),
+            }
+          : event
+      )
+    );
+  };
+
+  const openModal = (date: string) => {
+    setModal({ open: true, date, title: "", channel: "Blog" });
+  };
+
+  const closeModal = () => setModal((state) => ({ ...state, open: false }));
+
+  const submitModal = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setEvents((prev) => [
+      ...prev,
+      {
+        id: `new-${Date.now()}`,
+        title: modal.title || "Nouveau contenu",
+        plannedAt: `${modal.date}T09:00:00.000Z`,
+        status: "idea",
+        channel: modal.channel,
+        contentId: "cnt-new",
+      },
+    ]);
+    closeModal();
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Calendrier éditorial</h1>
+          <p className="text-sm text-muted-foreground">
+            Faites glisser pour replanifier rapidement ou utilisez le bouton « Replanifier ».
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={onExport}>
+            <Download className="mr-2 h-4 w-4" /> Export .ics
+          </Button>
+          <div className="inline-flex rounded-md border">
+            <Button
+              variant={view === "month" ? "default" : "ghost"}
+              onClick={() => setView("month")}
+              className="rounded-none"
+            >
+              <CalendarIcon className="mr-2 h-4 w-4" /> Mois
+            </Button>
+            <Button
+              variant={view === "week" ? "default" : "ghost"}
+              onClick={() => setView("week")}
+              className="rounded-none"
+            >
+              <CalendarIcon className="mr-2 h-4 w-4" /> Semaine
+            </Button>
+            <Button
+              variant={view === "list" ? "default" : "ghost"}
+              onClick={() => setView("list")}
+              className="rounded-none"
+            >
+              <List className="mr-2 h-4 w-4" /> Liste
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex items-center justify-between rounded-lg border bg-card px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" onClick={() => changeMonth(-1)} aria-label="Mois précédent">
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-lg font-semibold capitalize">{currentMonthLabel}</span>
+          <Button variant="ghost" size="icon" onClick={() => changeMonth(1)} aria-label="Mois suivant">
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          Quota hebdo total : {weeklyQuota} contenus • Double-clic pour planifier un contenu
+        </div>
+      </div>
+
+      {view === "month" && (
+        <div className="grid grid-cols-7 gap-2">
+          {["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"].map((label) => (
+            <div key={label} className="px-2 text-xs font-medium text-muted-foreground">
+              {label}
+            </div>
+          ))}
+          {matrix.map(({ date, key, events: dayEvents }) => {
+            const isCurrentMonth = date.getUTCMonth() === currentDate.getUTCMonth();
+            const intensityClass = heatLevel(dayEvents.length, Math.max(1, Math.round(weeklyQuota / 5)));
+            return (
+              <div
+                key={key}
+                onDoubleClick={() => openModal(key)}
+                className={`min-h-[120px] rounded-lg border p-2 text-xs transition-colors ${
+                  isCurrentMonth ? "bg-background" : "bg-muted"
+                }`}
+              >
+                <div className="mb-1 flex items-center justify-between">
+                  <span className={`font-medium ${isCurrentMonth ? "" : "text-muted-foreground"}`}>
+                    {date.getUTCDate()}
+                  </span>
+                  <span className={`h-3 w-12 rounded-full ${intensityClass}`} />
+                </div>
+                <div className="space-y-1">
+                  {dayEvents.map((event) => (
+                    <div key={event.id} className="rounded bg-primary/10 p-2 text-[11px]">
+                      <Link to={`/app/contents/${event.contentId}`} className="font-medium hover:underline">
+                        {event.title}
+                      </Link>
+                      <div className="mt-1 flex items-center justify-between">
+                        <span>{event.channel}</span>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-[11px]"
+                          onClick={() => onReplan(event.id)}
+                        >
+                          Replanifier
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {view === "week" && (
+        <div className="space-y-3">
+          {weekEvents.length > 0 ? (
+            weekEvents.map((event) => (
+              <div key={event.id} className="flex flex-wrap items-center justify-between rounded-lg border p-4">
+                <div>
+                  <Link to={`/app/contents/${event.contentId}`} className="font-medium hover:underline">
+                    {event.title}
+                  </Link>
+                  <div className="text-sm text-muted-foreground">
+                    {toDateKey(event.plannedAt)} • {event.channel} • {event.status}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button variant="outline" size="sm" asChild>
+                    <Link to={`/app/contents/${event.contentId}`}>Détail</Link>
+                  </Button>
+                  <Button variant="secondary" size="sm" onClick={() => onReplan(event.id)}>
+                    Replanifier
+                  </Button>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Aucun contenu programmé cette semaine.
+            </div>
+          )}
+        </div>
+      )}
+
+      {view === "list" && (
+        <div className="space-y-3">
+          {upcomingList.map((event) => (
+            <div key={event.id} className="flex flex-wrap items-center justify-between rounded-lg border p-3">
+              <div>
+                <Link to={`/app/contents/${event.contentId}`} className="font-medium hover:underline">
+                  {event.title}
+                </Link>
+                <div className="text-xs text-muted-foreground">
+                  {toDateKey(event.plannedAt)} • {event.channel} • Statut {event.status}
+                </div>
+              </div>
+              <Button variant="ghost" size="sm" onClick={() => onReplan(event.id)}>
+                Replanifier
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {modal.open && (
+        <div className="fixed inset-0 z-30 grid place-items-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-xl">
+            <div className="mb-4">
+              <h2 className="text-lg font-semibold">Nouveau contenu</h2>
+              <p className="text-sm text-muted-foreground">Création rapide pour le {modal.date}</p>
+            </div>
+            <form className="space-y-4" onSubmit={submitModal}>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Titre</label>
+                <Input
+                  value={modal.title}
+                  onChange={(event) => setModal((state) => ({ ...state, title: event.target.value }))}
+                  placeholder="Titre du contenu"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Canal</label>
+                <select
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                  value={modal.channel}
+                  onChange={(event) => setModal((state) => ({ ...state, channel: event.target.value }))}
+                >
+                  {Object.keys(organization.quotas.weekly).map((channel) => (
+                    <option key={channel} value={channel}>
+                      {channel}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="outline" onClick={closeModal}>
+                  Annuler
+                </Button>
+                <Button type="submit">Planifier</Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/app/ContentCreatePage.tsx
+++ b/src/components/app/ContentCreatePage.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { supportedChannels } from "@/lib/mockAppData";
+
+export default function ContentCreatePage() {
+  return (
+    <Card className="max-w-3xl">
+      <CardHeader>
+        <CardTitle>Nouveau contenu</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div>
+          <label className="text-sm font-medium">Titre</label>
+          <Input className="mt-1" placeholder="Titre du contenu" />
+        </div>
+        <div>
+          <label className="text-sm font-medium">Canal</label>
+          <select className="mt-1 w-full rounded-md border bg-background px-3 py-2">
+            {supportedChannels.map((channel) => (
+              <option key={channel}>{channel}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="text-sm font-medium">Date cible</label>
+          <Input type="date" className="mt-1" />
+        </div>
+        <Button>Créer le sujet</Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/app/ContentDetailPage.tsx
+++ b/src/components/app/ContentDetailPage.tsx
@@ -1,0 +1,389 @@
+import React from "react";
+import { useParams, Link } from "react-router-dom";
+import {
+  getContentById,
+  alfieInsights,
+  mockContents,
+} from "@/lib/mockAppData";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Bot,
+  Copy,
+  Archive,
+  Trash2,
+  Share2,
+  CheckCircle2,
+  AlertTriangle,
+  ExternalLink,
+} from "lucide-react";
+
+const formatDateTime = (value: string) =>
+  new Intl.DateTimeFormat("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+
+export default function ContentDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const content = id ? getContentById(id) : undefined;
+
+  if (!content) {
+    return (
+      <Card className="max-w-xl">
+        <CardHeader>
+          <CardTitle>Contenu introuvable</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            La ressource demandée n'existe pas ou a été archivée. Retournez à la liste des contenus pour poursuivre.
+          </p>
+          <Button asChild>
+            <Link to="/app/contents">Retour à la liste</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const checklistCount = Object.values(content.checklist).filter(Boolean).length;
+  const checklistProgress = Math.round((checklistCount / 4) * 100);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-3xl font-semibold">{content.title}</h1>
+            <Badge variant="outline">{content.channel}</Badge>
+            <Badge variant="secondary">{content.status}</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Slug : <span className="font-mono">{content.slug || "à définir"}</span>
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" size="sm">
+            <Copy className="mr-2 h-4 w-4" /> Dupliquer
+          </Button>
+          <Button variant="outline" size="sm">
+            <Archive className="mr-2 h-4 w-4" /> Archiver
+          </Button>
+          <Button variant="destructive" size="sm">
+            <Trash2 className="mr-2 h-4 w-4" /> Supprimer
+          </Button>
+          <Button size="sm" variant="secondary">
+            <CheckCircle2 className="mr-2 h-4 w-4" /> Marquer comme publié
+          </Button>
+        </div>
+      </header>
+
+      <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Métadonnées</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Titre</label>
+                  <Input defaultValue={content.title} />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Slug</label>
+                  <Input defaultValue={content.slug} />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Assignee</label>
+                  <Input defaultValue={content.assignee} />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Priorité</label>
+                  <select defaultValue={content.priority} className="w-full rounded-md border bg-background px-3 py-2 text-sm">
+                    <option value="low">Basse</option>
+                    <option value="medium">Normale</option>
+                    <option value="high">Haute</option>
+                  </select>
+                </div>
+              </div>
+              <div>
+                <span className="text-sm font-medium">Tags</span>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {content.tags.map((tag) => (
+                    <Badge key={tag} variant="outline">
+                      #{tag}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Planning & checklist</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Date de publication</label>
+                  <Input type="datetime-local" defaultValue={content.plannedAt?.slice(0, 16)} />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Échéance interne</label>
+                  <Input type="date" defaultValue={content.dueDate} />
+                </div>
+              </div>
+              <div>
+                <div className="flex items-center justify-between text-sm font-medium">
+                  <span>Avancement</span>
+                  <span>{checklistProgress}%</span>
+                </div>
+                <Progress value={checklistProgress} className="mt-2" />
+              </div>
+              <div className="grid gap-2 md:grid-cols-2">
+                {Object.entries(content.checklist).map(([key, value]) => (
+                  <label key={key} className="flex items-center gap-2 text-sm">
+                    <input type="checkbox" defaultChecked={value} />
+                    {key.charAt(0).toUpperCase() + key.slice(1)}
+                  </label>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Liens & pièces jointes</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <h3 className="font-medium">Liens</h3>
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-primary">
+                  {content.links.length > 0 ? (
+                    content.links.map((link) => (
+                      <li key={link.url}>
+                        <a href={link.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1">
+                          {link.label}
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-muted-foreground">Aucun lien renseigné.</li>
+                  )}
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="font-medium">Pièces jointes</h3>
+                <ul className="mt-2 space-y-2 text-sm">
+                  {content.attachments.length > 0 ? (
+                    content.attachments.map((attachment) => (
+                      <li key={attachment.id} className="flex items-center justify-between rounded border px-3 py-2">
+                        <span>{attachment.name}</span>
+                        <a
+                          href={attachment.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center gap-1 text-primary hover:underline"
+                        >
+                          Ouvrir <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </li>
+                    ))
+                  ) : (
+                    <li className="rounded border border-dashed px-3 py-2 text-muted-foreground">
+                      Aucune pièce jointe pour le moment.
+                    </li>
+                  )}
+                </ul>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Historique</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              {content.history.length > 0 ? (
+                content.history.map((entry) => (
+                  <div key={entry.id} className="rounded border px-3 py-2">
+                    <p className="font-medium">{entry.actor} {entry.action}</p>
+                    <p className="text-xs text-muted-foreground">{formatDateTime(entry.timestamp)}</p>
+                    {entry.details && <p className="mt-1 text-xs text-muted-foreground">{entry.details}</p>}
+                  </div>
+                ))
+              ) : (
+                <p className="text-muted-foreground">Aucun historique enregistré.</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Commentaires</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-3">
+                {content.comments.length > 0 ? (
+                  content.comments.map((comment) => (
+                    <div key={comment.id} className="rounded border px-3 py-2 text-sm">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium">{comment.author}</span>
+                        <span className="text-xs text-muted-foreground">{formatDateTime(comment.timestamp)}</span>
+                      </div>
+                      <p className="mt-2 whitespace-pre-line">
+                        {comment.message.split(" ").map((word) =>
+                          word.startsWith("@") ? (
+                            <span key={word} className="text-primary">
+                              {word}{" "}
+                            </span>
+                          ) : (
+                            `${word} `
+                          )
+                        )}
+                      </p>
+                    </div>
+                  ))
+                ) : (
+                  <div className="rounded border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
+                    Aucun commentaire pour l'instant.
+                  </div>
+                )}
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Ajouter un commentaire</label>
+                <textarea className="min-h-[90px] w-full rounded-md border bg-background px-3 py-2 text-sm" placeholder="@Nom pour mentionner un membre" />
+                <div className="flex justify-end gap-2">
+                  <Button variant="outline" size="sm">
+                    Prévisualiser
+                  </Button>
+                  <Button size="sm">
+                    Publier
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <aside className="space-y-6">
+          {content.antiOverlap?.hasConflict && (
+            <Card className="border-warning/60 bg-warning/10">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-warning-foreground">
+                  <AlertTriangle className="h-4 w-4" /> Risque de chevauchement
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <p>{content.antiOverlap?.message}</p>
+                <ul className="list-disc pl-4 text-sm">
+                  {content.antiOverlap?.suggestions.map((suggestion) => (
+                    <li key={suggestion}>{suggestion}</li>
+                  ))}
+                </ul>
+                <Button variant="outline" size="sm" asChild>
+                  <Link to="/app/plan">Voir les autres sujets</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Bot className="h-4 w-4" /> Alfie Copilot
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <p className="text-muted-foreground">Choisissez une action pour accélérer votre production.</p>
+              <div className="grid gap-2">
+                <Button variant="outline" size="sm">
+                  Générer un plan détaillé
+                </Button>
+                <Button variant="outline" size="sm">
+                  Réécrire en version courte
+                </Button>
+                <Button variant="outline" size="sm">
+                  Adapter le ton (Mémoire tonale)
+                </Button>
+              </div>
+              <div className="rounded-md bg-muted p-3">
+                <p className="text-xs text-muted-foreground">Suggestion</p>
+                <p className="text-sm">{alfieInsights[0]}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Mémoire tonale</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div className="space-y-1">
+                <label className="text-xs uppercase text-muted-foreground">Formel ↔ Amical</label>
+                <input type="range" defaultValue={content.brandVoice?.formel ?? 50} min={0} max={100} className="w-full" />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs uppercase text-muted-foreground">Expert ↔ Accessible</label>
+                <input type="range" defaultValue={content.brandVoice?.expert ?? 50} min={0} max={100} className="w-full" />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs uppercase text-muted-foreground">Énergie</label>
+                <input type="range" defaultValue={content.brandVoice?.energy ?? 50} min={0} max={100} className="w-full" />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Les réglages sont appliqués aux prochaines suggestions d'Alfie et aux déclinaisons sociales.
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Contenus liés</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              {mockContents
+                .filter((item) => item.channel === content.channel && item.id !== content.id)
+                .slice(0, 3)
+                .map((item) => (
+                  <div key={item.id} className="rounded border px-3 py-2">
+                    <Link to={`/app/contents/${item.id}`} className="font-medium hover:underline">
+                      {item.title}
+                    </Link>
+                    <p className="text-xs text-muted-foreground">Statut {item.status}</p>
+                  </div>
+                ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Partage</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <p className="text-muted-foreground">
+                Partagez ce contenu avec des parties prenantes externes via un lien sécurisé.
+              </p>
+              <Button variant="outline" size="sm" className="w-full">
+                <Share2 className="mr-2 h-4 w-4" /> Générer un lien d'aperçu
+              </Button>
+              <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
+                Historique partagé : 0 consultation • Expire dans 7 jours après activation.
+              </div>
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/components/app/ContentImportPage.tsx
+++ b/src/components/app/ContentImportPage.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function ContentImportPage() {
+  return (
+    <Card className="max-w-2xl">
+      <CardHeader>
+        <CardTitle>Import CSV</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <p>
+          Importez un CSV avec les colonnes <strong>titre</strong>, <strong>canal</strong>, <strong>date</strong> et <strong>assigné</strong>.
+          Les lignes sont vérifiées pour détecter les chevauchements.
+        </p>
+        <Button variant="outline">Choisir un fichier</Button>
+        <Button>Importer</Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/app/ContentsListPage.tsx
+++ b/src/components/app/ContentsListPage.tsx
@@ -1,0 +1,217 @@
+import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { mockContents, ContentItem, ContentStatus } from "@/lib/mockAppData";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Download, Upload, Check, Trash2 } from "lucide-react";
+
+const statusLabels: Record<ContentStatus, string> = {
+  idea: "Idée",
+  draft: "Brouillon",
+  review: "Révision",
+  ready: "Prêt",
+  scheduled: "Planifié",
+  published: "Publié",
+  archived: "Archivé",
+};
+
+const priorityLabels: Record<ContentItem["priority"], string> = {
+  low: "Basse",
+  medium: "Normale",
+  high: "Haute",
+};
+
+const formatDate = (value?: string) =>
+  value ? new Intl.DateTimeFormat("fr-FR", { day: "2-digit", month: "2-digit" }).format(new Date(value)) : "-";
+
+export default function ContentsListPage() {
+  const [items, setItems] = useState<ContentItem[]>(() => mockContents.map((item) => ({ ...item })));
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState<string[]>([]);
+  const [bulkAction, setBulkAction] = useState("status-ready");
+
+  const filtered = useMemo(() => {
+    if (!search) return items;
+    return items.filter((item) =>
+      [item.title, item.channel, item.assignee, item.tags.join(" ")]
+        .join(" ")
+        .toLowerCase()
+        .includes(search.toLowerCase())
+    );
+  }, [items, search]);
+
+  const toggleSelection = (id: string) => {
+    setSelected((prev) => (prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]));
+  };
+
+  const toggleAll = () => {
+    if (selected.length === filtered.length) {
+      setSelected([]);
+    } else {
+      setSelected(filtered.map((item) => item.id));
+    }
+  };
+
+  const exportCsv = () => {
+    const headers = [
+      "Titre",
+      "Statut",
+      "Canal",
+      "Assigné",
+      "Date cible",
+      "Priorité",
+      "Dernière mise à jour",
+    ];
+    const rows = items.map((item) => [
+      item.title,
+      statusLabels[item.status],
+      item.channel,
+      item.assignee,
+      item.dueDate ?? "",
+      priorityLabels[item.priority],
+      item.lastUpdated,
+    ]);
+    const csv = [headers, ...rows]
+      .map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(";"))
+      .join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "aeditus-contents.csv";
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importCsv = () => {
+    alert("Import CSV simulé — connecter Supabase pour l'upload réel.");
+  };
+
+  const applyBulk = () => {
+    if (selected.length === 0) return;
+    if (bulkAction.startsWith("status-")) {
+      const status = bulkAction.replace("status-", "") as ContentStatus;
+      setItems((prev) => prev.map((item) => (selected.includes(item.id) ? { ...item, status } : item)));
+    }
+    if (bulkAction.startsWith("delete")) {
+      setItems((prev) => prev.filter((item) => !selected.includes(item.id)));
+    }
+    setSelected([]);
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Contenus</h1>
+          <p className="text-sm text-muted-foreground">
+            Gérez vos sujets, articles et déclinaisons. Tous les titres mènent à la fiche détaillée.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Rechercher un contenu"
+            className="w-64"
+          />
+          <Button variant="outline" onClick={importCsv}>
+            <Upload className="mr-2 h-4 w-4" /> Import CSV
+          </Button>
+          <Button onClick={exportCsv}>
+            <Download className="mr-2 h-4 w-4" /> Export CSV
+          </Button>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3 rounded-lg border bg-card p-3 text-sm">
+        <span className="font-medium">Actions groupées</span>
+        <select
+          className="rounded-md border bg-background px-3 py-2"
+          value={bulkAction}
+          onChange={(event) => setBulkAction(event.target.value)}
+        >
+          <option value="status-ready">Marquer comme prêt</option>
+          <option value="status-scheduled">Planifier</option>
+          <option value="status-published">Marquer comme publié</option>
+          <option value="delete">Supprimer</option>
+        </select>
+        <Button variant="secondary" size="sm" onClick={applyBulk} disabled={selected.length === 0}>
+          <Check className="mr-2 h-4 w-4" /> Appliquer ({selected.length})
+        </Button>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full min-w-[720px] text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="px-3 py-2 text-left">
+                <input type="checkbox" aria-label="Tout sélectionner" onChange={toggleAll} checked={selected.length === filtered.length && filtered.length > 0} />
+              </th>
+              <th className="px-3 py-2 text-left">Titre</th>
+              <th className="px-3 py-2 text-left">Statut</th>
+              <th className="px-3 py-2 text-left">Canal</th>
+              <th className="px-3 py-2 text-left">Assigné</th>
+              <th className="px-3 py-2 text-left">Date cible</th>
+              <th className="px-3 py-2 text-left">Priorité</th>
+              <th className="px-3 py-2 text-left">Dernière MAJ</th>
+              <th className="px-3 py-2 text-left">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((item) => (
+              <tr key={item.id} className="border-b last:border-none">
+                <td className="px-3 py-3">
+                  <input
+                    type="checkbox"
+                    aria-label={`Sélectionner ${item.title}`}
+                    checked={selected.includes(item.id)}
+                    onChange={() => toggleSelection(item.id)}
+                  />
+                </td>
+                <td className="px-3 py-3">
+                  <Link to={`/app/contents/${item.id}`} className="font-medium hover:underline">
+                    {item.title}
+                  </Link>
+                  <div className="text-xs text-muted-foreground">{item.tags.join(", ")}</div>
+                </td>
+                <td className="px-3 py-3">
+                  <Badge variant="outline">{statusLabels[item.status]}</Badge>
+                </td>
+                <td className="px-3 py-3">{item.channel}</td>
+                <td className="px-3 py-3">{item.assignee}</td>
+                <td className="px-3 py-3">{formatDate(item.dueDate)}</td>
+                <td className="px-3 py-3">{priorityLabels[item.priority]}</td>
+                <td className="px-3 py-3">{formatDate(item.lastUpdated)}</td>
+                <td className="px-3 py-3">
+                  <div className="flex flex-wrap gap-2">
+                    <Button variant="outline" size="sm" asChild>
+                      <Link to={`/app/contents/${item.id}`}>Ouvrir</Link>
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive"
+                      onClick={() => setItems((prev) => prev.filter((content) => content.id !== item.id))}
+                    >
+                      <Trash2 className="mr-1 h-4 w-4" />
+                      Supprimer
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={9} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  Aucun contenu ne correspond à votre recherche.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/app/FynkPage.tsx
+++ b/src/components/app/FynkPage.tsx
@@ -1,0 +1,113 @@
+import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { fynkQueue, fynkCalendarHighlights } from "@/lib/mockAppData";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Calendar, PlayCircle, PauseCircle } from "lucide-react";
+
+export default function FynkPage() {
+  const [autoPilot, setAutoPilot] = useState(true);
+  const queue = useMemo(() => fynkQueue, []);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Fynk — Automatisation sociale</h1>
+          <p className="text-sm text-muted-foreground">
+            Gérez la file d'attente LinkedIn, les relances d'engagement et surveillez l'exécution automatique.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" asChild>
+            <Link to="/app/billing">Configurer la facturation</Link>
+          </Button>
+          <Button onClick={() => setAutoPilot((prev) => !prev)}>
+            {autoPilot ? (
+              <>
+                <PauseCircle className="mr-2 h-4 w-4" /> Mettre en pause
+              </>
+            ) : (
+              <>
+                <PlayCircle className="mr-2 h-4 w-4" /> Relancer
+              </>
+            )}
+          </Button>
+        </div>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>File d'attente</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          {queue.map((item) => (
+            <div key={item.id} className="flex flex-wrap items-center justify-between rounded border px-3 py-2">
+              <div>
+                <p className="font-medium">{item.title}</p>
+                <p className="text-xs text-muted-foreground">
+                  {new Intl.DateTimeFormat("fr-FR", {
+                    day: "2-digit",
+                    month: "short",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  }).format(new Date(item.scheduledAt))} • {item.channel}
+                </p>
+              </div>
+              <Badge variant={item.status === "Programmé" ? "secondary" : "outline"}>{item.status}</Badge>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Calendar className="h-4 w-4" /> Points chauds
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            {fynkCalendarHighlights.map((highlight) => (
+              <div key={highlight.date} className="rounded border px-3 py-2">
+                <p className="font-medium">{highlight.date}</p>
+                <p className="text-muted-foreground">{highlight.label}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Relances d'engagement</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p className="text-muted-foreground">
+              Automatisation en cours. Fynk notifie les rédacteurs lorsque des réponses nécessitent un suivi humain.
+            </p>
+            <ul className="list-disc space-y-1 pl-5">
+              <li>8 réponses LinkedIn analysées dans les dernières 24h</li>
+              <li>3 messages proposés pour demain matin</li>
+              <li>Score d'engagement moyen : 32 %</li>
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Statut de l'add-on</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p>
+            Add-on actif. Facturation via Stripe, prochaine facture le 01/02. Pour désactiver Fynk, utilisez le portail de facturation.
+          </p>
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/app/billing">Accéder au portail Stripe</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app/HelpPage.tsx
+++ b/src/components/app/HelpPage.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function HelpPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Aide & support</h1>
+        <p className="text-sm text-muted-foreground">
+          Accédez à la documentation, contactez l'équipe Æditus et découvrez la roadmap.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle>Documentation</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p>Guides étape par étape pour le plan éditorial, le calendrier et Alfie.</p>
+            <Button variant="outline" size="sm" asChild>
+              <a href="https://help.aeditus.com" target="_blank" rel="noreferrer">
+                Ouvrir
+              </a>
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Support</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p>Chat en direct 24/7 et escalade vers l'équipe humaine en cas de besoin.</p>
+            <Button variant="outline" size="sm" asChild>
+              <a href="mailto:support@aeditus.com">Envoyer un email</a>
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Roadmap</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p>Votez pour les prochaines fonctionnalités et suivez l'avancement.</p>
+            <Button variant="outline" size="sm" asChild>
+              <a href="/platform/roadmap">Voir la roadmap</a>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/app/PlanPage.tsx
+++ b/src/components/app/PlanPage.tsx
@@ -1,0 +1,238 @@
+import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  ContentItem,
+  ContentStatus,
+  mockContents,
+} from "@/lib/mockAppData";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown, Filter, MoveRight } from "lucide-react";
+
+const columns: { status: ContentStatus; label: string }[] = [
+  { status: "idea", label: "Idée" },
+  { status: "draft", label: "Brouillon" },
+  { status: "review", label: "Révision" },
+  { status: "ready", label: "Prêt" },
+  { status: "scheduled", label: "Planifié" },
+  { status: "published", label: "Publié" },
+];
+
+const statusLabels: Record<ContentStatus, string> = {
+  idea: "Idée",
+  draft: "Brouillon",
+  review: "Révision",
+  ready: "Prêt",
+  scheduled: "Planifié",
+  published: "Publié",
+  archived: "Archivé",
+};
+
+type Filters = {
+  assignee: string;
+  channel: string;
+  tag: string;
+  search: string;
+};
+
+const initialFilters: Filters = {
+  assignee: "",
+  channel: "",
+  tag: "",
+  search: "",
+};
+
+export default function PlanPage() {
+  const [items, setItems] = useState<ContentItem[]>(() => mockContents.map((item) => ({ ...item })));
+  const [filters, setFilters] = useState(initialFilters);
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+
+  const assignees = useMemo(
+    () => Array.from(new Set(mockContents.map((item) => item.assignee))).sort(),
+    []
+  );
+  const channels = useMemo(
+    () => Array.from(new Set(mockContents.map((item) => item.channel))).sort(),
+    []
+  );
+  const tags = useMemo(
+    () => Array.from(new Set(mockContents.flatMap((item) => item.tags))).sort(),
+    []
+  );
+
+  const filteredItems = useMemo(() => {
+    return items.filter((item) => {
+      if (filters.assignee && item.assignee !== filters.assignee) return false;
+      if (filters.channel && item.channel !== filters.channel) return false;
+      if (filters.tag && !item.tags.includes(filters.tag)) return false;
+      if (filters.search && !item.title.toLowerCase().includes(filters.search.toLowerCase())) return false;
+      return true;
+    });
+  }, [items, filters]);
+
+  const grouped = useMemo(() => {
+    return columns.map(({ status }) => ({
+      status,
+      label: statusLabels[status],
+      cards: filteredItems.filter((item) => item.status === status),
+    }));
+  }, [filteredItems]);
+
+  const handleMove = (id: string, status: ContentStatus) => {
+    setItems((prev) => prev.map((item) => (item.id === id ? { ...item, status } : item)));
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Plan éditorial</h1>
+          <p className="text-sm text-muted-foreground">Glissez-déposez ou utilisez "Déplacer vers…" pour mettre à jour le statut.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <div className="relative">
+            <Input
+              value={filters.search}
+              onChange={(event) => setFilters((prev) => ({ ...prev, search: event.target.value }))}
+              placeholder="Rechercher un titre"
+              className="w-56"
+            />
+          </div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Filter className="h-4 w-4" />
+            Filtres
+          </div>
+          <select
+            className="rounded-md border bg-background px-3 py-2 text-sm"
+            value={filters.assignee}
+            onChange={(event) => setFilters((prev) => ({ ...prev, assignee: event.target.value }))}
+          >
+            <option value="">Tous les assignés</option>
+            {assignees.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+          <select
+            className="rounded-md border bg-background px-3 py-2 text-sm"
+            value={filters.channel}
+            onChange={(event) => setFilters((prev) => ({ ...prev, channel: event.target.value }))}
+          >
+            <option value="">Tous les canaux</option>
+            {channels.map((channel) => (
+              <option key={channel} value={channel}>
+                {channel}
+              </option>
+            ))}
+          </select>
+          <select
+            className="rounded-md border bg-background px-3 py-2 text-sm"
+            value={filters.tag}
+            onChange={(event) => setFilters((prev) => ({ ...prev, tag: event.target.value }))}
+          >
+            <option value="">Tous les tags</option>
+            {tags.map((tag) => (
+              <option key={tag} value={tag}>
+                {tag}
+              </option>
+            ))}
+          </select>
+          <Button variant="ghost" size="sm" onClick={() => setFilters(initialFilters)}>
+            Réinitialiser
+          </Button>
+        </div>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
+        {grouped.map((column) => (
+          <div
+            key={column.status}
+            className="flex flex-col rounded-xl border bg-card"
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={(event) => {
+              event.preventDefault();
+              const id = draggedId ?? event.dataTransfer.getData("text/plain");
+              if (id) {
+                handleMove(id, column.status);
+              }
+              setDraggedId(null);
+            }}
+          >
+            <div className="flex items-center justify-between border-b px-3 py-2">
+              <span className="font-medium">{column.label}</span>
+              <Badge variant="secondary">{column.cards.length}</Badge>
+            </div>
+            <div className="flex-1 space-y-3 px-3 py-4">
+              {column.cards.length > 0 ? (
+                column.cards.map((card) => (
+                  <article
+                    key={card.id}
+                    className="space-y-3 rounded-lg border bg-background p-3 shadow-sm"
+                    draggable
+                    onDragStart={(event) => {
+                      setDraggedId(card.id);
+                      event.dataTransfer.setData("text/plain", card.id);
+                    }}
+                    onDragEnd={() => setDraggedId(null)}
+                  >
+                    <div className="space-y-1">
+                      <Link to={`/app/contents/${card.id}`} className="font-medium hover:underline">
+                        {card.title}
+                      </Link>
+                      <p className="text-xs text-muted-foreground">
+                        {card.channel} • {card.assignee}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {card.tags.map((tag) => (
+                        <Badge key={tag} variant="outline">
+                          #{tag}
+                        </Badge>
+                      ))}
+                    </div>
+                    <div className="flex items-center justify-between text-xs text-muted-foreground">
+                      <span>Priorité : {card.priority}</span>
+                      {card.dueDate && <span>Échéance {card.dueDate}</span>}
+                    </div>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="outline" size="sm" className="w-full">
+                          Déplacer vers…
+                          <ChevronDown className="ml-2 h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-44">
+                        {columns.map(({ status, label }) => (
+                          <DropdownMenuItem
+                            key={status}
+                            onSelect={() => handleMove(card.id, status)}
+                            disabled={status === card.status}
+                          >
+                            <MoveRight className="mr-2 h-4 w-4" />
+                            {label}
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </article>
+                ))
+              ) : (
+                <div className="rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground">
+                  Aucun contenu ici
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/app/SettingsPage.tsx
+++ b/src/components/app/SettingsPage.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useAppLayoutContext } from "./AppLayout";
+import { teamMembers, supportedChannels } from "@/lib/mockAppData";
+import { Badge } from "@/components/ui/badge";
+
+export default function SettingsPage() {
+  const { user, organization } = useAppLayoutContext();
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Paramètres</h1>
+        <p className="text-sm text-muted-foreground">Mettez à jour votre profil et configurez l'organisation.</p>
+      </header>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Profil</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <label className="text-sm font-medium">Prénom</label>
+                <Input defaultValue={user.firstName} className="mt-1" />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Email</label>
+                <Input defaultValue={user.email} className="mt-1" />
+              </div>
+            </div>
+            <Button size="sm">Enregistrer</Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Préférences</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div>
+              <label className="text-sm font-medium">Langue</label>
+              <select className="mt-1 w-full rounded-md border bg-background px-3 py-2">
+                <option>Français</option>
+                <option>Anglais</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Format date</label>
+              <select className="mt-1 w-full rounded-md border bg-background px-3 py-2">
+                <option>JJ/MM/AAAA</option>
+                <option>MM/JJ/AAAA</option>
+              </select>
+            </div>
+            <Button size="sm" variant="outline">
+              Sauvegarder
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Organisation</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="text-sm font-medium">Nom de l'organisation</label>
+              <Input defaultValue={organization.name} className="mt-1" />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Quota mensuel total</label>
+              <Input
+                type="number"
+                defaultValue={Object.values(organization.quotas.monthly).reduce((sum, value) => sum + value, 0)}
+                className="mt-1"
+              />
+            </div>
+          </div>
+          <div>
+            <p className="font-medium">Canaux activés</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {supportedChannels.map((channel) => {
+                const isActive = Object.prototype.hasOwnProperty.call(organization.quotas.weekly, channel);
+                return (
+                  <Badge key={channel} variant={isActive ? "secondary" : "outline"}>
+                    {channel}
+                  </Badge>
+                );
+              })}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Rôles & accès</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <table className="w-full min-w-[480px] text-sm">
+            <thead className="bg-muted/40">
+              <tr>
+                <th className="px-3 py-2 text-left">Membre</th>
+                <th className="px-3 py-2 text-left">Email</th>
+                <th className="px-3 py-2 text-left">Rôle</th>
+              </tr>
+            </thead>
+            <tbody>
+              {teamMembers.map((member) => (
+                <tr key={member.id} className="border-b last:border-none">
+                  <td className="px-3 py-2">{member.name}</td>
+                  <td className="px-3 py-2">{member.email}</td>
+                  <td className="px-3 py-2">
+                    <select
+                      className="rounded-md border bg-background px-2 py-1 text-xs"
+                      defaultValue={member.role}
+                    >
+                      <option value="owner">Owner</option>
+                      <option value="admin">Admin</option>
+                      <option value="editor">Editor</option>
+                      <option value="viewer">Viewer</option>
+                    </select>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <Button size="sm" variant="outline">
+            Inviter un membre
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app/TaskCreatePage.tsx
+++ b/src/components/app/TaskCreatePage.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export default function TaskCreatePage() {
+  return (
+    <Card className="max-w-2xl">
+      <CardHeader>
+        <CardTitle>Nouvelle tâche</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div>
+          <label className="text-sm font-medium">Titre</label>
+          <Input className="mt-1" placeholder="Décrire la tâche" />
+        </div>
+        <div>
+          <label className="text-sm font-medium">Échéance</label>
+          <Input type="date" className="mt-1" />
+        </div>
+        <Button>Créer</Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/app/TasksPage.tsx
+++ b/src/components/app/TasksPage.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { mockTasks, TaskItem, TaskStatus } from "@/lib/mockAppData";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown } from "lucide-react";
+
+const columns: { status: TaskStatus; label: string }[] = [
+  { status: "todo", label: "À faire" },
+  { status: "doing", label: "En cours" },
+  { status: "done", label: "Fait" },
+];
+
+export default function TasksPage() {
+  const [tasks, setTasks] = useState<TaskItem[]>(() => mockTasks.map((task) => ({ ...task })));
+
+  const moveTask = (id: string, status: TaskStatus) => {
+    setTasks((prev) => prev.map((task) => (task.id === id ? { ...task, status } : task)));
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Tâches</h1>
+          <p className="text-sm text-muted-foreground">
+            Suivez la production opérationnelle et reliez chaque tâche à son contenu parent.
+          </p>
+        </div>
+        <Button asChild>
+          <Link to="/app/tasks/new">Nouvelle tâche</Link>
+        </Button>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {columns.map(({ status, label }) => (
+          <div key={status} className="flex flex-col rounded-lg border bg-card">
+            <div className="flex items-center justify-between border-b px-3 py-2">
+              <span className="font-medium">{label}</span>
+              <Badge variant="secondary">{tasks.filter((task) => task.status === status).length}</Badge>
+            </div>
+            <div className="flex-1 space-y-3 px-3 py-4">
+              {tasks.filter((task) => task.status === status).length > 0 ? (
+                tasks
+                  .filter((task) => task.status === status)
+                  .map((task) => (
+                    <article key={task.id} className="space-y-3 rounded border bg-background p-3">
+                      <div>
+                        <h3 className="font-medium">{task.title}</h3>
+                        <p className="text-xs text-muted-foreground">
+                          Assigné à {task.assignee}
+                          {task.dueDate ? ` • Échéance ${task.dueDate}` : ""}
+                        </p>
+                      </div>
+                      {task.contentId && (
+                        <Link to={`/app/contents/${task.contentId}`} className="inline-flex text-sm text-primary hover:underline">
+                          Voir le contenu associé
+                        </Link>
+                      )}
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="outline" size="sm" className="w-full">
+                            Déplacer vers…
+                            <ChevronDown className="ml-2 h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          {columns.map((column) => (
+                            <DropdownMenuItem
+                              key={column.status}
+                              disabled={column.status === task.status}
+                              onSelect={() => moveTask(task.id, column.status)}
+                            >
+                              {column.label}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </article>
+                  ))
+              ) : (
+                <div className="rounded border border-dashed p-4 text-center text-sm text-muted-foreground">
+                  Rien à afficher ici.
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/landing/NewLandingPage.tsx
+++ b/src/components/landing/NewLandingPage.tsx
@@ -63,6 +63,17 @@ const sub = "text-base md:text-lg text-white/70";
 const pill =
   "inline-flex items-center gap-2 rounded-full border border-indigo-400/30 bg-indigo-400/10 px-3 py-1 text-indigo-200 text-xs font-medium";
 
+const bubblePositions = [
+  { left: "5%", top: "18%", delay: 0.2, duration: 12 },
+  { left: "18%", top: "70%", delay: 0.8, duration: 14 },
+  { left: "32%", top: "42%", delay: 1.4, duration: 11 },
+  { left: "46%", top: "10%", delay: 0.6, duration: 15 },
+  { left: "60%", top: "55%", delay: 0.3, duration: 13 },
+  { left: "74%", top: "24%", delay: 1.1, duration: 12 },
+  { left: "82%", top: "68%", delay: 0.5, duration: 16 },
+  { left: "12%", top: "88%", delay: 1.2, duration: 10 },
+];
+
 // Helpers
 const euro = (n: number) =>
   new Intl.NumberFormat("fr-FR", { style: "currency", currency: "EUR", maximumFractionDigits: 2 }).format(n);
@@ -213,6 +224,20 @@ export default function AeditusLanding() {
     []
   );
 
+  const handleAuditRequest = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const email = (formData.get("email") as string) ?? "";
+    const site = (formData.get("site") as string) ?? "";
+    const objectif = (formData.get("objectif") as string) ?? "";
+    const subject = encodeURIComponent("Audit éditorial Æditus");
+    const body = encodeURIComponent(`Email : ${email}\nSite : ${site}\nObjectif : ${objectif}`);
+    if (typeof window !== "undefined") {
+      window.open(`mailto:hello@aeditus.com?subject=${subject}&body=${body}`, "_blank");
+    }
+    event.currentTarget.reset();
+  };
+
   return (
     <div className="min-h-screen scroll-smooth bg-[#0B1110] text-white [--ring:#6366F1]">
       {/* Background FX */}
@@ -223,14 +248,14 @@ export default function AeditusLanding() {
         <motion.div className="absolute left-[-12rem] bottom-[-14rem] h-[28rem] w-[28rem] rounded-full bg-fuchsia-500/20 blur-[120px]" {...float(1.2)} />
 
         {/* tiny bubbles */}
-        {Array.from({ length: 14 }).map((_, i) => (
+        {bubblePositions.map((bubble, index) => (
           <motion.div
-            key={i}
+            key={`${bubble.left}-${bubble.top}-${index}`}
             className="absolute h-2 w-2 rounded-full bg-white/10"
-            style={{ left: (Math.random() * 100) + '%', top: (Math.random() * 100) + '%' }}
+            style={{ left: bubble.left, top: bubble.top }}
             initial={{ y: 0, opacity: 0.2, scale: 0.8 }}
             animate={{ y: [0, -12, 0, 10, 0], opacity: [0.2, 0.45, 0.25, 0.4, 0.2], scale: [0.8, 1, 0.9, 1.05, 0.8] }}
-            transition={{ duration: 12 + Math.random() * 6, delay: Math.random() * 2, repeat: Infinity, ease: "easeInOut" }}
+            transition={{ duration: bubble.duration, delay: bubble.delay, repeat: Infinity, ease: "easeInOut" }}
           />
         ))}
       </div>
@@ -422,6 +447,72 @@ export default function AeditusLanding() {
               </div>
             ))}
           </div>
+        </div>
+      </section>
+
+      {/* Audit éditorial CTA */}
+      <section className="border-b border-white/5 bg-white/5">
+        <div className={`${container} grid gap-10 py-16 md:grid-cols-2 md:py-20`}>
+          <div>
+            <motion.h2
+              variants={fadeUp}
+              initial="hidden"
+              whileInView="show"
+              viewport={{ once: true }}
+              className={h2}
+            >
+              Audit éditorial offert
+            </motion.h2>
+            <p className={`${sub} mt-3`}>
+              Analyse rapide de votre présence actuelle, recommandations de formats et proposition de calendrier
+              priorisé pour les 30 prochains jours.
+            </p>
+            <ul className="mt-4 space-y-2 text-sm text-white/70">
+              <li>✔️ Benchmark rapide de vos concurrents directs</li>
+              <li>✔️ 3 angles de sujets exclusifs validés par Alfie</li>
+              <li>✔️ Projection des quotas et charge interne associée</li>
+            </ul>
+          </div>
+          <form onSubmit={handleAuditRequest} className="rounded-2xl border border-white/10 bg-[#0E1514] p-6 space-y-4 text-sm">
+            <div>
+              <label className="text-sm font-medium text-white">Votre email professionnel</label>
+              <input
+                required
+                type="email"
+                name="email"
+                className="mt-2 w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+                placeholder="prenom@entreprise.com"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium text-white">Site / profil principal</label>
+              <input
+                required
+                type="url"
+                name="site"
+                className="mt-2 w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+                placeholder="https://..."
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium text-white">Objectif prioritaire</label>
+              <textarea
+                name="objectif"
+                rows={3}
+                className="mt-2 w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+                placeholder="Ex : Générer 20 RDV qualifiés / trimestre via LinkedIn"
+              />
+            </div>
+            <button
+              type="submit"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-500 px-4 py-2 text-sm font-semibold text-[#0B1110] hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
+            >
+              Recevoir mon audit en 48h
+            </button>
+            <p className="text-xs text-white/40">
+              Nous revenons vers vous sous 48h ouvrées. Aucun spam, aucune obligation d'achat.
+            </p>
+          </form>
         </div>
       </section>
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/src/lib/mockAppData.ts
+++ b/src/lib/mockAppData.ts
@@ -1,0 +1,543 @@
+export type ContentStatus =
+  | "idea"
+  | "draft"
+  | "review"
+  | "ready"
+  | "scheduled"
+  | "published"
+  | "archived";
+
+export type ContentPriority = "low" | "medium" | "high";
+
+export interface ContentChecklist {
+  research: boolean;
+  writing: boolean;
+  review: boolean;
+  ready: boolean;
+}
+
+export interface ContentLink {
+  label: string;
+  url: string;
+  type: "brief" | "source" | "asset" | "doc" | "publication";
+}
+
+export interface ContentAttachment {
+  id: string;
+  name: string;
+  url: string;
+  kind: string;
+}
+
+export interface ContentHistoryEntry {
+  id: string;
+  actor: string;
+  action: string;
+  timestamp: string;
+  details?: string;
+}
+
+export interface ContentComment {
+  id: string;
+  author: string;
+  message: string;
+  timestamp: string;
+  mentions?: string[];
+}
+
+export interface AntiOverlapInfo {
+  hasConflict: boolean;
+  message: string;
+  suggestions: string[];
+}
+
+export interface BrandVoiceDial {
+  formel: number;
+  expert: number;
+  energy: number;
+}
+
+export interface ContentItem {
+  id: string;
+  title: string;
+  slug: string;
+  status: ContentStatus;
+  channel: string;
+  assignee: string;
+  dueDate?: string;
+  plannedAt?: string;
+  priority: ContentPriority;
+  tags: string[];
+  lastUpdated: string;
+  createdAt: string;
+  summary: string;
+  checklist: ContentChecklist;
+  links: ContentLink[];
+  attachments: ContentAttachment[];
+  history: ContentHistoryEntry[];
+  comments: ContentComment[];
+  antiOverlap?: AntiOverlapInfo;
+  brandVoice?: BrandVoiceDial;
+}
+
+export type TaskStatus = "todo" | "doing" | "done";
+
+export interface TaskItem {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  assignee: string;
+  dueDate?: string;
+  contentId?: string;
+  channel?: string;
+}
+
+export interface ActivityItem {
+  id: string;
+  action: string;
+  target: string;
+  timestamp: string;
+  by: string;
+  type: "publication" | "validation" | "creation" | "edition" | "comment";
+}
+
+export interface AnalyticsSnapshot {
+  created: number;
+  published: number;
+  onTimeRate: number;
+  velocity: Array<{ user: string; value: number }>;
+  loadByChannel: Array<{ channel: string; planned: number; published: number }>;
+}
+
+export interface InvoiceItem {
+  id: string;
+  date: string;
+  amount: number;
+  status: "paid" | "due";
+  url: string;
+}
+
+export interface TeamMember {
+  id: string;
+  name: string;
+  role: "owner" | "admin" | "editor" | "viewer";
+  email: string;
+}
+
+export const mockOrganization = {
+  name: "Studio Nova",
+  quotas: {
+    weekly: { blog: 3, linkedin: 5, instagram: 4, youtube: 2 },
+    monthly: { blog: 12, linkedin: 20, instagram: 16, youtube: 8 },
+  },
+  trialEndsAt: "2025-02-01",
+  currentPlan: "Pro",
+  nextInvoiceDate: "2025-02-01",
+  fynkActive: true,
+};
+
+export const mockContents: ContentItem[] = [
+  {
+    id: "cnt-1",
+    title: "Article SEO — Tendances IA 2025",
+    slug: "article-seo-tendances-ia-2025",
+    status: "ready",
+    channel: "Blog",
+    assignee: "Nathalie",
+    dueDate: "2025-01-23",
+    plannedAt: "2025-01-23T09:00:00.000Z",
+    priority: "high",
+    tags: ["IA", "SEO"],
+    lastUpdated: "2025-01-19T10:15:00.000Z",
+    createdAt: "2025-01-08T08:00:00.000Z",
+    summary: "Analyse des tendances IA et des impacts pour les directions marketing.",
+    checklist: { research: true, writing: true, review: true, ready: false },
+    links: [
+      { label: "Brief Notion", url: "https://example.com/brief-ia", type: "brief" },
+      { label: "Sources Gartner", url: "https://example.com/gartner", type: "source" },
+    ],
+    attachments: [
+      {
+        id: "att-1",
+        name: "Mockups hero.png",
+        url: "https://example.com/mockup-hero.png",
+        kind: "image/png",
+      },
+    ],
+    history: [
+      {
+        id: "act-1",
+        actor: "Nathalie",
+        action: "a créé le contenu",
+        timestamp: "2025-01-08T08:05:00.000Z",
+      },
+      {
+        id: "act-2",
+        actor: "Marc",
+        action: "a validé le brief",
+        timestamp: "2025-01-10T14:15:00.000Z",
+      },
+      {
+        id: "act-3",
+        actor: "Sophie",
+        action: "a mis à jour le plan de diffusion",
+        timestamp: "2025-01-18T09:40:00.000Z",
+        details: "Ajout d'une déclinaison Instagram",
+      },
+    ],
+    comments: [
+      {
+        id: "com-1",
+        author: "Marc",
+        message: "Super intro. @Nathalie peux-tu préciser le chiffre clé dans le H2 ?",
+        timestamp: "2025-01-19T09:15:00.000Z",
+        mentions: ["Nathalie"],
+      },
+      {
+        id: "com-2",
+        author: "Nathalie",
+        message: "@Marc c'est fait, j'ai ajouté la stat Gartner dans la section 2.",
+        timestamp: "2025-01-19T10:05:00.000Z",
+        mentions: ["Marc"],
+      },
+    ],
+    antiOverlap: {
+      hasConflict: false,
+      message: "Aucun chevauchement détecté sur les 30 prochains jours.",
+      suggestions: [],
+    },
+    brandVoice: { formel: 45, expert: 70, energy: 60 },
+  },
+  {
+    id: "cnt-2",
+    title: "Post LinkedIn — Retour client GreenShift",
+    slug: "post-linkedin-retour-client-greenshift",
+    status: "draft",
+    channel: "LinkedIn",
+    assignee: "Marc",
+    dueDate: "2025-01-23",
+    plannedAt: "2025-01-23T15:00:00.000Z",
+    priority: "medium",
+    tags: ["Client", "LinkedIn"],
+    lastUpdated: "2025-01-19T11:45:00.000Z",
+    createdAt: "2025-01-15T09:00:00.000Z",
+    summary: "Mise en avant du ROI client avec carrousel visuel.",
+    checklist: { research: true, writing: false, review: false, ready: false },
+    links: [
+      { label: "Témoignage brut", url: "https://example.com/temoignage", type: "source" },
+    ],
+    attachments: [
+      {
+        id: "att-2",
+        name: "Carrousel Figma",
+        url: "https://example.com/carrousel.fig",
+        kind: "application/figma",
+      },
+    ],
+    history: [
+      {
+        id: "act-4",
+        actor: "Sophie",
+        action: "a assigné Marc",
+        timestamp: "2025-01-15T09:05:00.000Z",
+      },
+    ],
+    comments: [],
+    antiOverlap: {
+      hasConflict: true,
+      message: "Sujet proche de 'Case study GreenShift'.",
+      suggestions: [
+        "Changer l'angle sur l'équipe produit",
+        "Planifier à +7 jours",
+      ],
+    },
+    brandVoice: { formel: 30, expert: 55, energy: 75 },
+  },
+  {
+    id: "cnt-3",
+    title: "Story Instagram — Coulisses studio",
+    slug: "story-instagram-coulisses-studio",
+    status: "scheduled",
+    channel: "Instagram",
+    assignee: "Sophie",
+    dueDate: "2025-01-23",
+    plannedAt: "2025-01-23T18:00:00.000Z",
+    priority: "medium",
+    tags: ["Instagram", "Brand"],
+    lastUpdated: "2025-01-18T16:20:00.000Z",
+    createdAt: "2025-01-12T12:00:00.000Z",
+    summary: "Mini reportage en coulisses de la production vidéo.",
+    checklist: { research: true, writing: true, review: true, ready: true },
+    links: [
+      { label: "Storyboard", url: "https://example.com/storyboard", type: "doc" },
+    ],
+    attachments: [],
+    history: [
+      {
+        id: "act-5",
+        actor: "Sophie",
+        action: "a planifié la publication",
+        timestamp: "2025-01-18T16:20:00.000Z",
+      },
+    ],
+    comments: [],
+    brandVoice: { formel: 20, expert: 40, energy: 85 },
+  },
+  {
+    id: "cnt-4",
+    title: "Vidéo YouTube — Tutoriel complet",
+    slug: "video-youtube-tutoriel-complet",
+    status: "review",
+    channel: "YouTube",
+    assignee: "Sophie",
+    dueDate: "2025-01-24",
+    plannedAt: "2025-01-24T10:00:00.000Z",
+    priority: "high",
+    tags: ["YouTube", "Video"],
+    lastUpdated: "2025-01-19T12:30:00.000Z",
+    createdAt: "2025-01-05T08:00:00.000Z",
+    summary: "Tutoriel sur la programmation multi-plateformes Æditus.",
+    checklist: { research: true, writing: true, review: false, ready: false },
+    links: [
+      { label: "Script final", url: "https://example.com/script-video", type: "doc" },
+      { label: "Captations brutes", url: "https://example.com/captation", type: "asset" },
+    ],
+    attachments: [
+      {
+        id: "att-4",
+        name: "Miniature.png",
+        url: "https://example.com/miniature.png",
+        kind: "image/png",
+      },
+    ],
+    history: [
+      {
+        id: "act-6",
+        actor: "Marc",
+        action: "a demandé une révision",
+        timestamp: "2025-01-19T12:00:00.000Z",
+        details: "Ajouter les sous-titres FR/EN",
+      },
+    ],
+    comments: [
+      {
+        id: "com-3",
+        author: "Marc",
+        message: "Peux-tu intégrer le CTA vers la landing à 04:32 ?",
+        timestamp: "2025-01-19T12:05:00.000Z",
+        mentions: ["Sophie"],
+      },
+    ],
+    brandVoice: { formel: 35, expert: 65, energy: 80 },
+  },
+  {
+    id: "cnt-5",
+    title: "Newsletter — Synthèse mensuelle",
+    slug: "newsletter-synthese-janvier",
+    status: "draft",
+    channel: "Email",
+    assignee: "Nathalie",
+    dueDate: "2025-01-22",
+    plannedAt: "2025-01-22T08:00:00.000Z",
+    priority: "medium",
+    tags: ["Newsletter"],
+    lastUpdated: "2025-01-17T10:10:00.000Z",
+    createdAt: "2025-01-09T07:30:00.000Z",
+    summary: "Résumé des contenus et chiffres clés du mois.",
+    checklist: { research: true, writing: false, review: false, ready: false },
+    links: [
+      { label: "Outline", url: "https://example.com/outline-newsletter", type: "doc" },
+    ],
+    attachments: [],
+    history: [],
+    comments: [],
+    antiOverlap: {
+      hasConflict: false,
+      message: "",
+      suggestions: [],
+    },
+    brandVoice: { formel: 40, expert: 60, energy: 55 },
+  },
+  {
+    id: "cnt-6",
+    title: "Idée — Interview client Weave",
+    slug: "idee-interview-client-weave",
+    status: "idea",
+    channel: "Blog",
+    assignee: "Marc",
+    priority: "low",
+    tags: ["Client", "Interview"],
+    lastUpdated: "2025-01-16T09:45:00.000Z",
+    createdAt: "2025-01-16T09:45:00.000Z",
+    summary: "Interview croisée sur la collaboration avec Æditus.",
+    checklist: { research: false, writing: false, review: false, ready: false },
+    links: [],
+    attachments: [],
+    history: [],
+    comments: [],
+    brandVoice: { formel: 50, expert: 60, energy: 65 },
+  },
+];
+
+export const mockTasks: TaskItem[] = [
+  {
+    id: "task-1",
+    title: "Finaliser le H2 de l'article IA",
+    status: "doing",
+    assignee: "Nathalie",
+    dueDate: "2025-01-22",
+    contentId: "cnt-1",
+  },
+  {
+    id: "task-2",
+    title: "Uploader les sous-titres FR/EN",
+    status: "todo",
+    assignee: "Sophie",
+    dueDate: "2025-01-21",
+    contentId: "cnt-4",
+  },
+  {
+    id: "task-3",
+    title: "Valider le témoignage client",
+    status: "todo",
+    assignee: "Marc",
+    dueDate: "2025-01-20",
+    contentId: "cnt-2",
+  },
+  {
+    id: "task-4",
+    title: "Programmer les stories Instagram",
+    status: "done",
+    assignee: "Sophie",
+    dueDate: "2025-01-18",
+    contentId: "cnt-3",
+  },
+];
+
+export const mockActivity: ActivityItem[] = [
+  {
+    id: "activity-1",
+    action: "Publication",
+    target: "Story Instagram — Coulisses studio",
+    timestamp: "2025-01-19T18:05:00.000Z",
+    by: "Sophie",
+    type: "publication",
+  },
+  {
+    id: "activity-2",
+    action: "Validation",
+    target: "Article SEO — Tendances IA 2025",
+    timestamp: "2025-01-19T10:20:00.000Z",
+    by: "Marc",
+    type: "validation",
+  },
+  {
+    id: "activity-3",
+    action: "Création",
+    target: "Idée — Interview client Weave",
+    timestamp: "2025-01-16T09:45:00.000Z",
+    by: "Marc",
+    type: "creation",
+  },
+  {
+    id: "activity-4",
+    action: "Commentaire",
+    target: "Vidéo YouTube — Tutoriel complet",
+    timestamp: "2025-01-19T12:05:00.000Z",
+    by: "Marc",
+    type: "comment",
+  },
+];
+
+export const analyticsSnapshot: AnalyticsSnapshot = {
+  created: 32,
+  published: 26,
+  onTimeRate: 0.82,
+  velocity: [
+    { user: "Nathalie", value: 7 },
+    { user: "Marc", value: 6 },
+    { user: "Sophie", value: 8 },
+  ],
+  loadByChannel: [
+    { channel: "Blog", planned: 8, published: 6 },
+    { channel: "LinkedIn", planned: 10, published: 9 },
+    { channel: "Instagram", planned: 12, published: 10 },
+    { channel: "YouTube", planned: 4, published: 3 },
+  ],
+};
+
+export const mockInvoices: InvoiceItem[] = [
+  {
+    id: "inv-2024-11",
+    date: "2024-11-01",
+    amount: 399,
+    status: "paid",
+    url: "https://example.com/invoice/2024-11",
+  },
+  {
+    id: "inv-2024-12",
+    date: "2024-12-01",
+    amount: 399,
+    status: "paid",
+    url: "https://example.com/invoice/2024-12",
+  },
+  {
+    id: "inv-2025-01",
+    date: "2025-01-01",
+    amount: 399,
+    status: "paid",
+    url: "https://example.com/invoice/2025-01",
+  },
+];
+
+export const teamMembers: TeamMember[] = [
+  { id: "user-1", name: "Nathalie", role: "owner", email: "nathalie@aeditus.com" },
+  { id: "user-2", name: "Marc", role: "editor", email: "marc@aeditus.com" },
+  { id: "user-3", name: "Sophie", role: "editor", email: "sophie@aeditus.com" },
+  { id: "user-4", name: "Lina", role: "viewer", email: "lina@aeditus.com" },
+];
+
+export const supportedChannels = ["Blog", "LinkedIn", "Instagram", "YouTube", "Email", "Podcast"];
+
+export const fynkQueue = [
+  {
+    id: "fynk-1",
+    title: "Post LinkedIn — Lancement produit",
+    scheduledAt: "2025-01-22T08:30:00.000Z",
+    status: "En file",
+    channel: "LinkedIn",
+  },
+  {
+    id: "fynk-2",
+    title: "Post LinkedIn — Bilan semaine",
+    scheduledAt: "2025-01-24T09:00:00.000Z",
+    status: "Prêt à valider",
+    channel: "LinkedIn",
+  },
+  {
+    id: "fynk-3",
+    title: "Relance commentaires",
+    scheduledAt: "2025-01-24T17:00:00.000Z",
+    status: "Programmé",
+    channel: "LinkedIn",
+  },
+];
+
+export const fynkCalendarHighlights = [
+  {
+    date: "2025-01-22",
+    label: "3 publications automatiques",
+  },
+  {
+    date: "2025-01-24",
+    label: "Campagne relance",
+  },
+];
+
+export const alfieInsights = [
+  "Tu es à 78 % du quota hebdo LinkedIn. Ajoute 2 posts vendredi.",
+  "Les vidéos coulisses génèrent +24 % d'engagement, pense à en planifier une supplémentaire.",
+  "Les publications newsletter sont prêtes avec 2 jours d'avance cette semaine, bravo !",
+];
+
+export const getContentById = (id: string) => mockContents.find((content) => content.id === id);


### PR DESCRIPTION
## Summary
- implement complete authenticated workspace with structured dashboards, kanban, calendar, analytics and billing views using shared mock data
- add navigation context, quick actions and create/import screens so every sidebar entry resolves to a populated page
- refresh the public landing with deterministic visuals and an audit request CTA that opens a prefilled email

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ce47df99c4832ca3ba164d502f5933